### PR TITLE
IServiceProvider extension methods to check for service registrations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,14 @@
 
 - Added ServiceProvider extension methods to check if Registered Services are: Transient, Scoped, Singleton [#1](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/1)
 
+### Breaking Changes
+
+- `IServiceCollection` extension methods behavior changes:
+  - `IsTransientServiceRegistered`: looks for non-keyed services only.
+  - `IsScopedServiceRegistered`: looks for non-keyed services only.
+  - `IsSingletonServiceRegistered`: looks for non-keyed services only.
+  - Added `IsKeyedTransientServiceRegistered`, `IsKeyedScopedServiceRegistered`, `IsKeyedSingletonServiceRegistered` to check for keyed services.
+
 ## 0.3.0
 
 - Improved NuGet package (deterministic, source link).
@@ -24,27 +32,27 @@
 
   ```csharp
   var descriptors = new AssemblyInspector()
-  	.FromAssemblyContaining<TestService>()
-  	.BasedOn(typeof(TestService))
-  	.WithServiceBase()
-  	.LifestyleTransient(dependsOn: new Dependency[]
-  	{
-  		Parameter.ForKey("param").Eq("nonexisting")
-  	});
+    .FromAssemblyContaining<TestService>()
+    .BasedOn(typeof(TestService))
+    .WithServiceBase()
+    .LifestyleTransient(dependsOn: new Dependency[]
+    {
+        Parameter.ForKey("param").Eq("nonexisting")
+    });
   ```
   
   becomes:
   
   ```csharp
   var descriptors = new AssemblyInspector()
-  	.FromAssemblyContaining<TestService>()
-  	.BasedOn(typeof(TestService))
-  	.WithServiceBase()
-  	.Configure(cfg => cfg.DependsOn = new Dependency[]
-  	{
-  		Parameter.ForKey("param").Eq("nonexisting")
-  	})
-  	.LifestyleTransient();
+    .FromAssemblyContaining<TestService>()
+    .BasedOn(typeof(TestService))
+    .WithServiceBase()
+    .Configure(cfg => cfg.DependsOn = new Dependency[]
+    {
+        Parameter.ForKey("param").Eq("nonexisting")
+    })
+    .LifestyleTransient();
   ```
 
 ## 0.1.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Mammoth.Extensions.DependencyInjection
 
+## vNext
+
+- Added ServiceProvider extension methods to check if Registered Services are: Transient, Scoped, Singleton [#1](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/1)
+
 ## 0.3.0
 
 - Improved NuGet package (deterministic, source link).

--- a/README.md
+++ b/README.md
@@ -126,10 +126,14 @@ Helper methods to check if a service was registered or a ServiceDescriptor exist
 ##### ServiceCollection
 
 - `GetServiceDescriptors`: returns all the ServiceDescriptors (keyed and non keyed) of a given service type.
-- `IsServiceRegistered`
+- `IsServiceRegistered`: checks whether the specified service type is registered in the service collection (keyed or not).
+- `IsKeyedServiceRegistered`: checks whether the specified service type is registered as keyed in the service collection.
 - `IsTransientServiceRegistered`
 - `IsScopedServiceRegistered`
 - `IsSingletonServiceRegistered`
+- `IsKeyedTransientServiceRegistered`
+- `IsKeyedScopedServiceRegistered`
+- `IsKeyedSingletonServiceRegistered`
 
 ##### ServiceProvider
 
@@ -149,9 +153,13 @@ You can then use the following extensions:
 
 - `GetAllServices`: resolves all keyed and non-keyed services of a given service type.
 - `IsServiceRegistered`: checks whether the specified service type is registered in the service provider (keyed or non-keyed).
-- `IsTransientServiceRegistered`: checks whether the specified service type is registered as transient in the service provider (there are two versions to check for keyed and non keyed registrations).
-- `IsScopedServiceRegistered`: checks whether the specified service type is registered as scoped in the service provider (there are two versions to check for keyed and non keyed registrations).
-- `IsSingletonServiceRegistered`: checks whether the specified service type is registered as singleton in the service provider (there are two versions to check for keyed and non keyed registrations).
+- `IsKeyedServiceRegistered`: checks whether the specified service type is registered as keyed in the service provider.
+- `IsTransientServiceRegistered`: checks whether the specified service type is registered as transient in the service provider (non keyed services).
+- `IsScopedServiceRegistered`: checks whether the specified service type is registered as scoped in the service provider (non keyed services).
+- `IsSingletonServiceRegistered`: checks whether the specified service type is registered as singleton in the service provider (non keyed services).
+- `IsKeyedTransientServiceRegistered`: checks whether the specified service type is registered as transient in the service provider (keyed services).
+- `IsKeyedScopedServiceRegistered`: checks whether the specified service type is registered as scoped in the service provider (keyed services).
+- `IsKeyedSingletonServiceRegistered`: checks whether the specified service type is registered as singleton in the service provider (keyed services).
 
 #### Inspectors
 

--- a/README.md
+++ b/README.md
@@ -35,22 +35,22 @@ public class TestService : ITestService { }
 
 public class DecoratorService1 : ITestService
 {
-	private readonly ITestService _service;
+    private readonly ITestService _service;
 
-	public DecoratorService1(ITestService service)
-	{
-		_service = service;
-	}
+    public DecoratorService1(ITestService service)
+    {
+        _service = service;
+    }
 }
 
 public class DecoratorService2 : ITestService
 {
-	private readonly ITestService _service;
+    private readonly ITestService _service;
 
-	public DecoratorService2(ITestService service)
-	{
-		_service = service;
-	}
+    public DecoratorService2(ITestService service)
+    {
+        _service = service;
+    }
 }
 ```
 
@@ -60,7 +60,7 @@ services.Decorate<IService, DecoratorService1>(); // innermost decorator
 services.Decorate<IService, DecoratorService2>(); // outermost decorator
 ```
 
-This extensins works with all kinds of Service Descriptors (Singleton, Scoped, Transient, Keyed, etc).
+This extension works with all kinds of Service Descriptors (Singleton, Scoped, Transient, Keyed, etc).
 
 ### DependsOn (requires Keyed Services support)
 
@@ -75,12 +75,12 @@ public class TestService : ITestService { }
 
 public class DependentService
 {
-	private readonly ITestService _service;
+    private readonly ITestService _service;
 
-	public DependentService(ITestService service)
-	{
-		_service = service;
-	}
+    public DependentService(ITestService service)
+    {
+        _service = service;
+    }
 }
 ```
 
@@ -108,24 +108,24 @@ The current syntax is limited to some common use case and it's very similar to t
 
   ```csharp
   services.AddTransient<DependentService>(dependsOn: new Dependency[] {
-	Dependency.OnValue("dep", "val1")
+    Dependency.OnValue("dep", "val1")
   });
   ```
 
-This extensins works with all kinds of Service Descriptors (Singleton, Scoped, Transient, Keyed, etc).
+This extension works with all kinds of Service Descriptors (Singleton, Scoped, Transient, Keyed, etc).
 
 ### Registration Helpers
 
-A series of extentions and helpers methods to check is a component was registered and to 
+A series of extensions and helpers methods to check is a component was registered and to 
 inspect the assemblies looking for services to be registered.
 
 #### Checks
 
-Helper methods to check if a service was registered or a ServiceDescript exists.
+Helper methods to check if a service was registered or a ServiceDescriptor exists.
 
 ##### ServiceCollection
 
-- `GetServiceDescriptors`
+- `GetServiceDescriptors`: returns all the ServiceDescriptors (keyed and non keyed) of a given service type.
 - `IsServiceRegistered`
 - `IsTransientServiceRegistered`
 - `IsScopedServiceRegistered`
@@ -147,8 +147,11 @@ var serviceProvider = ServiceProviderFactory.CreateServiceProvider(serviceCollec
 
 You can then use the following extensions:
 
-- `IsServiceRegistered`
-- `GetAllServices`: resolves all keyed and non-keyed services of a given service type
+- `GetAllServices`: resolves all keyed and non-keyed services of a given service type.
+- `IsServiceRegistered`: checks whether the specified service type is registered in the service provider (keyed or non-keyed).
+- `IsTransientServiceRegistered`: checks whether the specified service type is registered as transient in the service provider (there are two versions to check for keyed and non keyed registrations).
+- `IsScopedServiceRegistered`: checks whether the specified service type is registered as scoped in the service provider (there are two versions to check for keyed and non keyed registrations).
+- `IsSingletonServiceRegistered`: checks whether the specified service type is registered as singleton in the service provider (there are two versions to check for keyed and non keyed registrations).
 
 #### Inspectors
 
@@ -164,12 +167,12 @@ It also supports the `DependsOn` registration extensions:
 ```csharp
 serviceCollection.Add(
   new AssemblyInspector()
-	.FromAssemblyContaining<ServiceWithKeyedDep>()
-	.BasedOn<ServiceWithKeyedDep>()
-	.WithServiceSelf()
-	.LifestyleSingleton(dependsOn: new Dependency[]
-	{
-	  Parameter.ForKey("keyedService").Eq("one")
+    .FromAssemblyContaining<ServiceWithKeyedDep>()
+    .BasedOn<ServiceWithKeyedDep>()
+    .WithServiceSelf()
+    .LifestyleSingleton(dependsOn: new Dependency[]
+    {
+      Parameter.ForKey("keyedService").Eq("one")
     })
 );
 ```

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceProviderExtensions.Registration.Tests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceProviderExtensions.Registration.Tests.cs
@@ -7,18 +7,6 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 	public class ServiceProviderExtensionsRegistrationTests
 	{
 		[TestMethod]
-		public void IsServiceRegistered_KeyedService_Throws_Because_ServiceProvider_Not_Configured()
-		{
-			var serviceCollection = new ServiceCollection();
-			var sp = serviceCollection.BuildServiceProvider();
-
-			Assert.ThrowsException<InvalidOperationException>(() => sp.IsServiceRegistered("service"));
-			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedSingletonServiceRegistered<TestService>("service"));
-			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedTransientServiceRegistered<TestService>("service"));
-			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedScopedServiceRegistered<TestService>("service"));
-		}
-
-		[TestMethod]
 		public void IsServiceRegistered_Throws_Because_ServiceProvider_Not_Configured()
 		{
 			var serviceCollection = new ServiceCollection();
@@ -43,6 +31,30 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
+		public void IsKeyedServiceRegistered_Throws_Because_ServiceProvider_Not_Configured()
+		{
+			var serviceCollection = new ServiceCollection();
+			var sp = serviceCollection.BuildServiceProvider();
+
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedServiceRegistered("service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedSingletonServiceRegistered(typeof(TestService), "service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedTransientServiceRegistered(typeof(TestService), "service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedScopedServiceRegistered(typeof(TestService), "service"));
+		}
+
+		[TestMethod]
+		public void IsKeyedServiceRegistered_Generic_Throws_Because_ServiceProvider_Not_Configured()
+		{
+			var serviceCollection = new ServiceCollection();
+			var sp = serviceCollection.BuildServiceProvider();
+
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedServiceRegistered("service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedSingletonServiceRegistered<TestService>("service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedTransientServiceRegistered<TestService>("service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedScopedServiceRegistered<TestService>("service"));
+		}
+
+		[TestMethod]
 		public void IsServiceRegistered_Return_False_If_a_ServiceType_was_Not_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
@@ -55,7 +67,19 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
-		public void IsServiceRegistered_Checking_ServiceKey_Return_False_If_a_Keyed_ServiceType_was_Not_Registered()
+		public void IsKeyedServiceRegistered_Return_False_If_a_ServiceType_was_Not_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsFalse(sp.IsKeyedServiceRegistered("one"));
+			Assert.IsFalse(sp.IsKeyedSingletonServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedTransientServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedScopedServiceRegistered<TestService>("one"));
+		}
+
+		[TestMethod]
+		public void IsKeyedServiceRegistered_Checking_ServiceKey_Return_False_If_a_Keyed_ServiceType_was_Not_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddKeyedSingleton<TestService>("one");
@@ -63,20 +87,20 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			serviceCollection.AddKeyedScoped<TestService>("one");
 			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
-			Assert.IsFalse(sp.IsServiceRegistered("two"));
+			Assert.IsFalse(sp.IsKeyedServiceRegistered("two"));
 			Assert.IsFalse(sp.IsKeyedSingletonServiceRegistered<TestService>("two"));
 			Assert.IsFalse(sp.IsKeyedTransientServiceRegistered<TestService>("two"));
 			Assert.IsFalse(sp.IsKeyedScopedServiceRegistered<TestService>("two"));
 		}
 
 		[TestMethod]
-		public void IsServiceRegistered_Checking_ServiceKey_for_Null_Throws_Exception()
+		public void IsKeyedServiceRegistered_Checking_ServiceKey_for_Null_Throws_Exception()
 		{
 			var serviceCollection = new ServiceCollection();
 			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-			Assert.ThrowsException<ArgumentNullException>(() => sp.IsServiceRegistered(serviceKey: null));
+			Assert.ThrowsException<ArgumentNullException>(() => sp.IsKeyedServiceRegistered(serviceKey: null));
 			Assert.ThrowsException<ArgumentNullException>(() => sp.IsKeyedSingletonServiceRegistered<TestService>(serviceKey: null));
 			Assert.ThrowsException<ArgumentNullException>(() => sp.IsKeyedTransientServiceRegistered<TestService>(serviceKey: null));
 			Assert.ThrowsException<ArgumentNullException>(() => sp.IsKeyedScopedServiceRegistered<TestService>(serviceKey: null));
@@ -97,7 +121,7 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
-		public void Singleton_IsServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		public void Singleton_IsKeyedServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddKeyedSingleton<TestService>("one");
@@ -115,13 +139,13 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
-		public void Singleton_IsServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		public void Singleton_IsKeyedServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddKeyedSingleton<TestService>("one");
 			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
-			Assert.IsTrue(sp.IsServiceRegistered("one"));
+			Assert.IsTrue(sp.IsKeyedServiceRegistered("one"));
 
 			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
 			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
@@ -146,7 +170,7 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
-		public void Scoped_IsServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		public void Scoped_IsKeyedServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddKeyedScoped<TestService>("one");
@@ -164,13 +188,13 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
-		public void Scoped_IsServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		public void Scoped_IsKeyedServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddKeyedScoped<TestService>("one");
 			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
-			Assert.IsTrue(sp.IsServiceRegistered("one"));
+			Assert.IsTrue(sp.IsKeyedServiceRegistered("one"));
 
 			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
 			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
@@ -195,7 +219,7 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
-		public void Transient_IsServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		public void Transient_IsKeyedServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddKeyedTransient<TestService>("one");
@@ -213,13 +237,13 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
-		public void Transient_IsServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		public void Transient_IsKeyedServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddKeyedTransient<TestService>("one");
 			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
-			Assert.IsTrue(sp.IsServiceRegistered("one"));
+			Assert.IsTrue(sp.IsKeyedServiceRegistered("one"));
 
 			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
 			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceProviderExtensions.Registration.Tests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceProviderExtensions.Registration.Tests.cs
@@ -13,6 +13,9 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			var sp = serviceCollection.BuildServiceProvider();
 
 			Assert.ThrowsException<InvalidOperationException>(() => sp.IsServiceRegistered("service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedSingletonServiceRegistered<TestService>("service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedTransientServiceRegistered<TestService>("service"));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsKeyedScopedServiceRegistered<TestService>("service"));
 		}
 
 		[TestMethod]
@@ -21,7 +24,10 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			var serviceCollection = new ServiceCollection();
 			var sp = serviceCollection.BuildServiceProvider();
 
-			Assert.ThrowsException<InvalidOperationException>(() => sp.IsServiceRegistered<TestService>());
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsServiceRegistered(typeof(TestService)));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsSingletonServiceRegistered(typeof(TestService)));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsTransientServiceRegistered(typeof(TestService)));
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsScopedServiceRegistered(typeof(TestService)));
 		}
 
 		[TestMethod]
@@ -31,46 +37,21 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			var sp = serviceCollection.BuildServiceProvider();
 
 			Assert.ThrowsException<InvalidOperationException>(() => sp.IsServiceRegistered<TestService>());
-		}
-
-		[TestMethod]
-		public void IsServiceRegistered_Return_True_If_a_ServiceType_was_Registered()
-		{
-			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddSingleton<TestService>();
-			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
-
-			Assert.IsTrue(sp.IsServiceRegistered<TestService>());
-		}
-
-		[TestMethod]
-		public void IsServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
-		{
-			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddKeyedSingleton<TestService>("one");
-			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
-
-			Assert.IsTrue(sp.IsServiceRegistered<TestService>());
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsSingletonServiceRegistered<TestService>());
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsTransientServiceRegistered<TestService>());
+			Assert.ThrowsException<InvalidOperationException>(() => sp.IsScopedServiceRegistered<TestService>());
 		}
 
 		[TestMethod]
 		public void IsServiceRegistered_Return_False_If_a_ServiceType_was_Not_Registered()
 		{
 			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddSingleton<TestService>();
 			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
-			Assert.IsFalse(sp.IsServiceRegistered<AnotherTestService>());
-		}
-
-		[TestMethod]
-		public void IsServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
-		{
-			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddKeyedSingleton<TestService>("one");
-			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
-
-			Assert.IsTrue(sp.IsServiceRegistered("one"));
+			Assert.IsFalse(sp.IsServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
 		}
 
 		[TestMethod]
@@ -78,21 +59,175 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		{
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddKeyedSingleton<TestService>("one");
+			serviceCollection.AddKeyedTransient<TestService>("one");
+			serviceCollection.AddKeyedScoped<TestService>("one");
 			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
 			Assert.IsFalse(sp.IsServiceRegistered("two"));
+			Assert.IsFalse(sp.IsKeyedSingletonServiceRegistered<TestService>("two"));
+			Assert.IsFalse(sp.IsKeyedTransientServiceRegistered<TestService>("two"));
+			Assert.IsFalse(sp.IsKeyedScopedServiceRegistered<TestService>("two"));
 		}
 
 		[TestMethod]
 		public void IsServiceRegistered_Checking_ServiceKey_for_Null_Throws_Exception()
 		{
 			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddSingleton<TestService>();
 			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 			Assert.ThrowsException<ArgumentNullException>(() => sp.IsServiceRegistered(serviceKey: null));
+			Assert.ThrowsException<ArgumentNullException>(() => sp.IsKeyedSingletonServiceRegistered<TestService>(serviceKey: null));
+			Assert.ThrowsException<ArgumentNullException>(() => sp.IsKeyedTransientServiceRegistered<TestService>(serviceKey: null));
+			Assert.ThrowsException<ArgumentNullException>(() => sp.IsKeyedScopedServiceRegistered<TestService>(serviceKey: null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+		}
+
+		[TestMethod]
+		public void Singleton_IsServiceRegistered_Return_True_If_a_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton<TestService>();
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered<TestService>());
+			Assert.IsTrue(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void Singleton_IsServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedSingleton<TestService>("one");
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered<TestService>());
+
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
+
+			Assert.IsTrue(sp.IsKeyedSingletonServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedTransientServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedScopedServiceRegistered<TestService>("one"));
+		}
+
+		[TestMethod]
+		public void Singleton_IsServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedSingleton<TestService>("one");
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered("one"));
+
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
+
+			Assert.IsTrue(sp.IsKeyedSingletonServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedTransientServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedScopedServiceRegistered<TestService>("one"));
+		}
+
+		[TestMethod]
+		public void Scoped_IsServiceRegistered_Return_True_If_a_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddScoped<TestService>();
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsTrue(sp.IsScopedServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void Scoped_IsServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedScoped<TestService>("one");
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered<TestService>());
+
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
+
+			Assert.IsFalse(sp.IsKeyedSingletonServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedTransientServiceRegistered<TestService>("one"));
+			Assert.IsTrue(sp.IsKeyedScopedServiceRegistered<TestService>("one"));
+		}
+
+		[TestMethod]
+		public void Scoped_IsServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedScoped<TestService>("one");
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered("one"));
+
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
+
+			Assert.IsFalse(sp.IsKeyedSingletonServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedTransientServiceRegistered<TestService>("one"));
+			Assert.IsTrue(sp.IsKeyedScopedServiceRegistered<TestService>("one"));
+		}
+
+		[TestMethod]
+		public void Transient_IsServiceRegistered_Return_True_If_a_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TestService>();
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void Transient_IsServiceRegistered_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedTransient<TestService>("one");
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered<TestService>());
+
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
+
+			Assert.IsFalse(sp.IsKeyedSingletonServiceRegistered<TestService>("one"));
+			Assert.IsTrue(sp.IsKeyedTransientServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedScopedServiceRegistered<TestService>("one"));
+		}
+
+		[TestMethod]
+		public void Transient_IsServiceRegistered_Checking_ServiceKey_Return_True_If_a_Keyed_ServiceType_was_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedTransient<TestService>("one");
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			Assert.IsTrue(sp.IsServiceRegistered("one"));
+
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());
+
+			Assert.IsFalse(sp.IsKeyedSingletonServiceRegistered<TestService>("one"));
+			Assert.IsTrue(sp.IsKeyedTransientServiceRegistered<TestService>("one"));
+			Assert.IsFalse(sp.IsKeyedScopedServiceRegistered<TestService>("one"));
 		}
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.KeyedService.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.KeyedService.cs
@@ -538,6 +538,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			services.TryAddKeyedTransient<TService>(serviceKey, KeyedDependsOnResolutionFunc<TImplementation>(dependsOn, ctor, parameter));
 		}
 
+#pragma warning disable RCS1224 // Make method an extension method
 		internal static Func<IServiceProvider, TTarget> DependsOnResolutionFunc<TTarget>(Dependency[] dependsOn, ConstructorInfo ctor, ParameterInfo[] parameter) where TTarget : class
 		{
 			return sp =>
@@ -621,5 +622,6 @@ namespace Mammoth.Extensions.DependencyInjection
 				.First();
 			parameter = ctor.GetParameters();
 		}
+#pragma warning restore RCS1224 // Make method an extension method
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Reflection.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Reflection.cs
@@ -6,7 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Mammoth.Extensions.DependencyInjection {
+namespace Mammoth.Extensions.DependencyInjection
+{
 	// Instead of using reflection to access internal properties of the service provider, consider using the following approach:
 	// Resolve all services: another approach to consider is "enumerate all keys": https://github.com/dotnet/runtime/issues/91466#issuecomment-1723532096
 	// We can create a custom factory provider that will register some structure with all the
@@ -19,15 +20,18 @@ namespace Mammoth.Extensions.DependencyInjection {
 	/// <summary>
 	/// Provides extension methods for <see cref="IServiceProvider"/>.
 	/// </summary>
-	public static class ServiceProviderExtensions {
+	public static class ServiceProviderExtensions
+	{
 		/// <summary>
 		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
 		/// </summary>
 		/// <remarks>
 		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
 		/// </remarks>
-		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, Type serviceType) {
-			if (serviceType is null) {
+		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+		{
+			if (serviceType is null)
+			{
 				throw new ArgumentNullException(nameof(serviceType));
 			}
 
@@ -41,7 +45,8 @@ namespace Mammoth.Extensions.DependencyInjection {
 		/// <remarks>
 		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
 		/// </remarks>
-		public static bool IsServiceRegistered<TService>(this IServiceProvider serviceProvider) {
+		public static bool IsServiceRegistered<TService>(this IServiceProvider serviceProvider)
+		{
 			return IsServiceRegistered(serviceProvider, typeof(TService));
 		}
 
@@ -51,8 +56,10 @@ namespace Mammoth.Extensions.DependencyInjection {
 		/// <remarks>
 		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
 		/// </remarks>
-		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey) {
-			if (serviceKey is null) {
+		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
+		{
+			if (serviceKey is null)
+			{
 				throw new ArgumentNullException(nameof(serviceKey));
 			}
 
@@ -67,9 +74,11 @@ namespace Mammoth.Extensions.DependencyInjection {
 		/// <para>WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.</para>
 		/// <para>WARNING: It might be removed once enumerating all services with KeyedService.AnyKey work as expected.</para>
 		/// </remarks>
-		public static IEnumerable<object> GetAllServices(this IServiceProvider serviceProvider, Type serviceType) {
+		public static IEnumerable<object> GetAllServices(this IServiceProvider serviceProvider, Type serviceType)
+		{
 			var descriptors = GetServiceDescriptors(serviceProvider);
-			if (descriptors == null) {
+			if (descriptors == null)
+			{
 				return Enumerable.Empty<object>();
 			}
 			// find out all the unique services keyed names
@@ -80,9 +89,11 @@ namespace Mammoth.Extensions.DependencyInjection {
 				.ToList();
 			var serviceList = new List<object>();
 			// null key to get all non-keyed services
-			foreach (var serviceKey in serviceKeys) {
+			foreach (var serviceKey in serviceKeys)
+			{
 				var services = serviceProvider.GetKeyedServices(serviceType, serviceKey);
-				if (services?.Any() == true) {
+				if (services?.Any() == true)
+				{
 					serviceList.AddRange(services!);
 				}
 			}
@@ -96,9 +107,11 @@ namespace Mammoth.Extensions.DependencyInjection {
 		/// <para>WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.</para>
 		/// <para>WARNING: It might be removed once enumerating all services with KeyedService.AnyKey work as expected.</para>
 		/// </remarks>
-		public static IEnumerable<TService> GetAllServices<TService>(this IServiceProvider serviceProvider) {
+		public static IEnumerable<TService> GetAllServices<TService>(this IServiceProvider serviceProvider)
+		{
 			var descriptors = GetServiceDescriptors(serviceProvider);
-			if (descriptors == null) {
+			if (descriptors == null)
+			{
 				return Enumerable.Empty<TService>();
 			}
 			// find out all the unique services keyed names
@@ -109,21 +122,26 @@ namespace Mammoth.Extensions.DependencyInjection {
 				.ToList();
 			var serviceList = new List<TService>();
 			// null key to get all non-keyed services
-			foreach (var serviceKey in serviceKeys) {
+			foreach (var serviceKey in serviceKeys)
+			{
 				var services = serviceProvider.GetKeyedServices<TService>(serviceKey);
-				if (services?.Any() == true) {
+				if (services?.Any() == true)
+				{
 					serviceList.AddRange(services!);
 				}
 			}
 			return serviceList;
 		}
 
-		private static IEnumerable<ServiceDescriptor> GetServiceDescriptors(IServiceProvider serviceProvider) {
+		private static IEnumerable<ServiceDescriptor> GetServiceDescriptors(IServiceProvider serviceProvider)
+		{
 			var callSiteFactoryProperty = serviceProvider.GetType().GetProperty("CallSiteFactory", BindingFlags.NonPublic | BindingFlags.Instance);
-			if (callSiteFactoryProperty != null) {
+			if (callSiteFactoryProperty != null)
+			{
 				var callSiteFactory = callSiteFactoryProperty.GetValue(serviceProvider);
 				var serviceDescriptorsProperty = callSiteFactory?.GetType().GetProperty("Descriptors", BindingFlags.NonPublic | BindingFlags.Instance);
-				if (serviceDescriptorsProperty != null) {
+				if (serviceDescriptorsProperty != null)
+				{
 					return (IEnumerable<ServiceDescriptor>)serviceDescriptorsProperty.GetValue(callSiteFactory);
 				}
 			}

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Registration.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Registration.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Mammoth.Extensions.DependencyInjection;
+
+public static partial class ServiceProviderExtensions
+{
+	/// <summary>
+	/// Determines whether the specified service type is registered as a transient service in the service provider.
+	/// </summary>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceType">The type of the service.</param>
+	/// <returns><c>true</c> if the service type is registered as transient; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceType is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsTransientServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+	{
+		if (serviceType is null)
+		{
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+
+		var lifetimes = serviceProvider.GetService<ServiceLifetimes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return lifetimes.GetLifetime(serviceType) == ServiceLifetime.Transient;
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type is registered as a transient service in the service provider.
+	/// </summary>
+	/// <typeparam name="TServiceType">The type of the service.</typeparam>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <returns><c>true</c> if the service type is registered as transient; otherwise, <c>false</c>.</returns>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsTransientServiceRegistered<TServiceType>(this IServiceProvider serviceProvider)
+	{
+		return IsTransientServiceRegistered(serviceProvider, typeof(TServiceType));
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type with the given key is registered as a transient service in the service provider.
+	/// </summary>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceType">The type of the service.</param>
+	/// <param name="serviceKey">The key of the service.</param>
+	/// <returns><c>true</c> if the service type with the specified key is registered as transient; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceType or serviceKey is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsTransientServiceRegistered(this IServiceProvider serviceProvider, Type serviceType, object serviceKey)
+	{
+		if (serviceType is null)
+		{
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+
+		if (serviceKey is null)
+		{
+			throw new ArgumentNullException(nameof(serviceKey));
+		}
+
+		var lifetimes = serviceProvider.GetService<ServiceLifetimes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return lifetimes.GetLifetime(serviceType, serviceKey) == ServiceLifetime.Transient;
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type with the given key is registered as a transient service in the service provider.
+	/// </summary>
+	/// <typeparam name="TServiceType">The type of the service.</typeparam>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceKey">The key of the service.</param>
+	/// <returns><c>true</c> if the service type with the specified key is registered as transient; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceKey is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsTransientServiceRegistered<TServiceType>(this IServiceProvider serviceProvider, object serviceKey)
+	{
+		return IsTransientServiceRegistered(serviceProvider, typeof(TServiceType), serviceKey);
+	}
+}

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Registration.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Registration.cs
@@ -30,7 +30,7 @@ public static partial class ServiceProviderExtensions
 	/// <summary>
 	/// Determines whether the specified service key is registered in the service provider.
 	/// </summary>
-	public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
+	public static bool IsKeyedServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
 	{
 		if (serviceKey is null)
 		{
@@ -191,32 +191,6 @@ public static partial class ServiceProviderExtensions
 		return IsKeyedSingletonServiceRegistered(serviceProvider, typeof(TServiceType), serviceKey);
 	}
 
-	/*
-	 * TODO
-	 * 
-	/// <summary>
-	/// Determines whether the specified service type with the given key is registered as a singleton service in the service provider (keyed).
-	/// </summary>
-	/// <param name="serviceProvider">The service provider.</param>
-	/// <param name="serviceType">The type of the service.</param>
-	/// <param name="serviceKey">The key of the service.</param>
-	/// <returns><c>true</c> if the service type with the specified key is registered as singleton; otherwise, <c>false</c>.</returns>
-	/// <exception cref="ArgumentNullException">Thrown when serviceType or serviceKey is null.</exception>
-	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
-	public static bool IsKeyedSingletonServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
-	{
-		if (serviceType is null)
-		{
-			throw new ArgumentNullException(nameof(serviceType));
-		}
-
-		var lifetimes = serviceProvider.GetService<ServiceLifetimes>()
-			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
-
-		return lifetimes.GetLifetime(serviceType, serviceKey) == ServiceLifetime.Singleton;
-	}
-	*/
-
 	/// <summary>
 	/// Determines whether the specified service type is registered as a scoped service in the service provider (non keyed).
 	/// </summary>
@@ -290,5 +264,4 @@ public static partial class ServiceProviderExtensions
 	{
 		return IsKeyedScopedServiceRegistered(serviceProvider, typeof(TServiceType), serviceKey);
 	}
-
 }

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Registration.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Registration.cs
@@ -5,7 +5,46 @@ namespace Mammoth.Extensions.DependencyInjection;
 public static partial class ServiceProviderExtensions
 {
 	/// <summary>
-	/// Determines whether the specified service type is registered as a transient service in the service provider.
+	/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+	/// </summary>
+	public static bool IsServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+	{
+		if (serviceType is null)
+		{
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+		var serviceTypes = serviceProvider.GetService<ServiceTypes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return serviceTypes.Any(type => type == serviceType);
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+	/// </summary>
+	public static bool IsServiceRegistered<TServiceType>(this IServiceProvider serviceProvider)
+	{
+		return IsServiceRegistered(serviceProvider, typeof(TServiceType));
+	}
+
+	/// <summary>
+	/// Determines whether the specified service key is registered in the service provider.
+	/// </summary>
+	public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
+	{
+		if (serviceKey is null)
+		{
+			throw new ArgumentNullException(nameof(serviceKey));
+		}
+
+		var serviceKeys = serviceProvider.GetService<ServiceKeys>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return serviceKeys.Any(key => key.Equals(serviceKey));
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type is registered as a transient service in the service provider (non keyed).
 	/// </summary>
 	/// <param name="serviceProvider">The service provider.</param>
 	/// <param name="serviceType">The type of the service.</param>
@@ -26,7 +65,7 @@ public static partial class ServiceProviderExtensions
 	}
 
 	/// <summary>
-	/// Determines whether the specified service type is registered as a transient service in the service provider.
+	/// Determines whether the specified service type is registered as a transient service in the service provider (non keyed).
 	/// </summary>
 	/// <typeparam name="TServiceType">The type of the service.</typeparam>
 	/// <param name="serviceProvider">The service provider.</param>
@@ -38,7 +77,7 @@ public static partial class ServiceProviderExtensions
 	}
 
 	/// <summary>
-	/// Determines whether the specified service type with the given key is registered as a transient service in the service provider.
+	/// Determines whether the specified service type with the given key is registered as a transient service in the service provider (keyed).
 	/// </summary>
 	/// <param name="serviceProvider">The service provider.</param>
 	/// <param name="serviceType">The type of the service.</param>
@@ -46,7 +85,7 @@ public static partial class ServiceProviderExtensions
 	/// <returns><c>true</c> if the service type with the specified key is registered as transient; otherwise, <c>false</c>.</returns>
 	/// <exception cref="ArgumentNullException">Thrown when serviceType or serviceKey is null.</exception>
 	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
-	public static bool IsTransientServiceRegistered(this IServiceProvider serviceProvider, Type serviceType, object serviceKey)
+	public static bool IsKeyedTransientServiceRegistered(this IServiceProvider serviceProvider, Type serviceType, object serviceKey)
 	{
 		if (serviceType is null)
 		{
@@ -65,7 +104,7 @@ public static partial class ServiceProviderExtensions
 	}
 
 	/// <summary>
-	/// Determines whether the specified service type with the given key is registered as a transient service in the service provider.
+	/// Determines whether the specified service type with the given key is registered as a transient service in the service provider (keyed).
 	/// </summary>
 	/// <typeparam name="TServiceType">The type of the service.</typeparam>
 	/// <param name="serviceProvider">The service provider.</param>
@@ -73,8 +112,183 @@ public static partial class ServiceProviderExtensions
 	/// <returns><c>true</c> if the service type with the specified key is registered as transient; otherwise, <c>false</c>.</returns>
 	/// <exception cref="ArgumentNullException">Thrown when serviceKey is null.</exception>
 	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
-	public static bool IsTransientServiceRegistered<TServiceType>(this IServiceProvider serviceProvider, object serviceKey)
+	public static bool IsKeyedTransientServiceRegistered<TServiceType>(this IServiceProvider serviceProvider, object serviceKey)
 	{
-		return IsTransientServiceRegistered(serviceProvider, typeof(TServiceType), serviceKey);
+		return IsKeyedTransientServiceRegistered(serviceProvider, typeof(TServiceType), serviceKey);
 	}
+
+	/// <summary>
+	/// Determines whether the specified service type is registered as a singleton service in the service provider (non keyed).
+	/// </summary>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceType">The type of the service.</param>
+	/// <returns><c>true</c> if the service type is registered as singleton; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceType is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsSingletonServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+	{
+		if (serviceType is null)
+		{
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+
+		var lifetimes = serviceProvider.GetService<ServiceLifetimes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return lifetimes.GetLifetime(serviceType) == ServiceLifetime.Singleton;
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type is registered as a singleton service in the service provider (non keyed).
+	/// </summary>
+	/// <typeparam name="TServiceType">The type of the service.</typeparam>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <returns><c>true</c> if the service type is registered as singleton; otherwise, <c>false</c>.</returns>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsSingletonServiceRegistered<TServiceType>(this IServiceProvider serviceProvider)
+	{
+		return IsSingletonServiceRegistered(serviceProvider, typeof(TServiceType));
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type with the given key is registered as a singleton service in the service provider (keyed).
+	/// </summary>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceType">The type of the service.</param>
+	/// <param name="serviceKey">The key of the service.</param>
+	/// <returns><c>true</c> if the service type with the specified key is registered as singleton; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceType or serviceKey is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsKeyedSingletonServiceRegistered(this IServiceProvider serviceProvider, Type serviceType, object serviceKey)
+	{
+		if (serviceType is null)
+		{
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+
+		if (serviceKey is null)
+		{
+			throw new ArgumentNullException(nameof(serviceKey));
+		}
+
+		var lifetimes = serviceProvider.GetService<ServiceLifetimes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return lifetimes.GetLifetime(serviceType, serviceKey) == ServiceLifetime.Singleton;
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type with the given key is registered as a singleton service in the service provider (keyed).
+	/// </summary>
+	/// <typeparam name="TServiceType">The type of the service.</typeparam>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceKey">The key of the service.</param>
+	/// <returns><c>true</c> if the service type with the specified key is registered as singleton; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceKey is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsKeyedSingletonServiceRegistered<TServiceType>(this IServiceProvider serviceProvider, object serviceKey)
+	{
+		return IsKeyedSingletonServiceRegistered(serviceProvider, typeof(TServiceType), serviceKey);
+	}
+
+	/*
+	 * TODO
+	 * 
+	/// <summary>
+	/// Determines whether the specified service type with the given key is registered as a singleton service in the service provider (keyed).
+	/// </summary>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceType">The type of the service.</param>
+	/// <param name="serviceKey">The key of the service.</param>
+	/// <returns><c>true</c> if the service type with the specified key is registered as singleton; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceType or serviceKey is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsKeyedSingletonServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+	{
+		if (serviceType is null)
+		{
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+
+		var lifetimes = serviceProvider.GetService<ServiceLifetimes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return lifetimes.GetLifetime(serviceType, serviceKey) == ServiceLifetime.Singleton;
+	}
+	*/
+
+	/// <summary>
+	/// Determines whether the specified service type is registered as a scoped service in the service provider (non keyed).
+	/// </summary>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceType">The type of the service.</param>
+	/// <returns><c>true</c> if the service type is registered as scoped; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceType is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsScopedServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+	{
+		if (serviceType is null)
+		{
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+
+		var lifetimes = serviceProvider.GetService<ServiceLifetimes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return lifetimes.GetLifetime(serviceType) == ServiceLifetime.Scoped;
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type is registered as a scoped service in the service provider (non keyed).
+	/// </summary>
+	/// <typeparam name="TServiceType">The type of the service.</typeparam>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <returns><c>true</c> if the service type is registered as scoped; otherwise, <c>false</c>.</returns>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsScopedServiceRegistered<TServiceType>(this IServiceProvider serviceProvider)
+	{
+		return IsScopedServiceRegistered(serviceProvider, typeof(TServiceType));
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type with the given key is registered as a scoped service in the service provider (keyed).
+	/// </summary>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceType">The type of the service.</param>
+	/// <param name="serviceKey">The key of the service.</param>
+	/// <returns><c>true</c> if the service type with the specified key is registered as scoped; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceType or serviceKey is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsKeyedScopedServiceRegistered(this IServiceProvider serviceProvider, Type serviceType, object serviceKey)
+	{
+		if (serviceType is null)
+		{
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+
+		if (serviceKey is null)
+		{
+			throw new ArgumentNullException(nameof(serviceKey));
+		}
+
+		var lifetimes = serviceProvider.GetService<ServiceLifetimes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+
+		return lifetimes.GetLifetime(serviceType, serviceKey) == ServiceLifetime.Scoped;
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type with the given key is registered as a scoped service in the service provider (keyed).
+	/// </summary>
+	/// <typeparam name="TServiceType">The type of the service.</typeparam>
+	/// <param name="serviceProvider">The service provider.</param>
+	/// <param name="serviceKey">The key of the service.</param>
+	/// <returns><c>true</c> if the service type with the specified key is registered as scoped; otherwise, <c>false</c>.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when serviceKey is null.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when the service provider was not built using the ServiceProviderFactory.</exception>
+	public static bool IsKeyedScopedServiceRegistered<TServiceType>(this IServiceProvider serviceProvider, object serviceKey)
+	{
+		return IsKeyedScopedServiceRegistered(serviceProvider, typeof(TServiceType), serviceKey);
+	}
+
 }

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.cs
@@ -1,125 +1,124 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace Mammoth.Extensions.DependencyInjection
+namespace Mammoth.Extensions.DependencyInjection;
+
+/// <summary>
+/// <para>
+/// Provides extension methods for <see cref="IServiceProvider"/>.
+/// To use the following extensions, you need to build the ServiceProvider calling:
+/// </para>
+/// <![CDATA[
+/// new HostBuilder().UseServiceProviderFactory(new ServiceProviderFactory());
+/// - or -
+/// var serviceProvider = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+/// ]]>
+/// <para>in order to use these extensions.</para>
+/// </summary>
+public static partial class ServiceProviderExtensions
 {
 	/// <summary>
-	/// <para>
-	/// Provides extension methods for <see cref="IServiceProvider"/>.
-	/// To use the following extensions, you need to build the ServiceProvider calling:
-	/// </para>
-	/// <![CDATA[
-	/// new HostBuilder().UseServiceProviderFactory(new ServiceProviderFactory());
-	/// - or -
-	/// var serviceProvider = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
-	/// ]]>
-	/// <para>in order to use these extensions.</para>
+	/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
 	/// </summary>
-	public static class ServiceProviderExtensions
+	public static bool IsServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
 	{
-		/// <summary>
-		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
-		/// </summary>
-		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+		if (serviceType is null)
 		{
-			if (serviceType is null)
-			{
-				throw new ArgumentNullException(nameof(serviceType));
-			}
-			var serviceTypes = serviceProvider.GetService<ServiceTypes>()
-				?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
+			throw new ArgumentNullException(nameof(serviceType));
+		}
+		var serviceTypes = serviceProvider.GetService<ServiceTypes>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
 
-			return serviceTypes.Any(type => type == serviceType);
+		return serviceTypes.Any(type => type == serviceType);
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+	/// </summary>
+	public static bool IsServiceRegistered<TServiceType>(this IServiceProvider serviceProvider)
+	{
+		return IsServiceRegistered(serviceProvider, typeof(TServiceType));
+	}
+
+	/// <summary>
+	/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+	/// </summary>
+	public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
+	{
+		if (serviceKey is null)
+		{
+			throw new ArgumentNullException(nameof(serviceKey));
 		}
 
-		/// <summary>
-		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
-		/// </summary>
-		public static bool IsServiceRegistered<TServiceType>(this IServiceProvider serviceProvider)
-		{
-			return IsServiceRegistered(serviceProvider, typeof(TServiceType));
-		}
+		var serviceKeys = serviceProvider.GetService<Keys>()
+			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
 
-		/// <summary>
-		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
-		/// </summary>
-		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
+		return serviceKeys.Any(key => key.Equals(serviceKey));
+	}
+
+	/// <summary>
+	/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
+	/// Order of services is not guaranteed to be the same as the order of registration:
+	/// - first will be resolved non-keyed services (in the order of registration)
+	/// - then all keyed services (keys will be sorted in ascending order, each key will be resolved, services inside the key will
+	///   be resolved in the order of registration)
+	/// </summary>
+	/// <remarks>
+	/// <para>WARNING: To use these extensions, you need to build the ServiceProvider using <see cref="ServiceProviderFactory"/>.</para>
+	/// </remarks>
+	public static IEnumerable<object?> GetAllServices(this IServiceProvider serviceProvider, Type serviceType)
+	{
+		var KeysType = typeof(Keys<>).MakeGenericType(serviceType);
+		var serviceList = new List<object?>();
+		// add null key to get all non-keyed services
+		serviceList.AddRange(serviceProvider.GetServices(serviceType));
+		if (serviceProvider.GetService(KeysType) is IEnumerable<object> keys)
 		{
-			if (serviceKey is null)
+			foreach (var serviceKey in keys!)
 			{
-				throw new ArgumentNullException(nameof(serviceKey));
-			}
-
-			var serviceKeys = serviceProvider.GetService<Keys>()
-				?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
-
-			return serviceKeys.Any(key => key.Equals(serviceKey));
-		}
-
-		/// <summary>
-		/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
-		/// Order of services is not guaranteed to be the same as the order of registration:
-		/// - first will be resolved non-keyed services (in the order of registration)
-		/// - then all keyed services (keys will be sorted in ascending order, each key will be resolved, services inside the key will
-		///   be resolved in the order of registration)
-		/// </summary>
-		/// <remarks>
-		/// <para>WARNING: To use these extensions, you need to build the ServiceProvider using <see cref="ServiceProviderFactory"/>.</para>
-		/// </remarks>
-		public static IEnumerable<object?> GetAllServices(this IServiceProvider serviceProvider, Type serviceType)
-		{
-			var KeysType = typeof(Keys<>).MakeGenericType(serviceType);
-			var serviceList = new List<object?>();
-			// add null key to get all non-keyed services
-			serviceList.AddRange(serviceProvider.GetServices(serviceType));
-			if (serviceProvider.GetService(KeysType) is IEnumerable<object> keys)
-			{
-				foreach (var serviceKey in keys!)
+				var services = serviceProvider.GetKeyedServices(serviceType, serviceKey);
+				if (services?.Any() == true)
 				{
-					var services = serviceProvider.GetKeyedServices(serviceType, serviceKey);
-					if (services?.Any() == true)
-					{
-						serviceList.AddRange(services!);
-					}
+					serviceList.AddRange(services!);
 				}
 			}
-			return serviceList;
 		}
+		return serviceList;
+	}
 
-		/// <summary>
-		/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
-		/// Order of services is not guaranteed to be the same as the order of registration:
-		/// - first will be resolved non-keyed services (in the order of registration)
-		/// - then all keyed services (keys will be sorted in ascending order, each key will be resolved, services inside the key will
-		///   be resolved in the order of registration)
-		/// </summary>
-		/// <remarks>
-		/// <para>WARNING: To use these extensions, you need to build the ServiceProvider using <see cref="ServiceProviderFactory"/>.</para>
-		/// </remarks>
-		public static IEnumerable<TServiceType> GetAllServices<TServiceType>(this IServiceProvider serviceProvider)
+	/// <summary>
+	/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
+	/// Order of services is not guaranteed to be the same as the order of registration:
+	/// - first will be resolved non-keyed services (in the order of registration)
+	/// - then all keyed services (keys will be sorted in ascending order, each key will be resolved, services inside the key will
+	///   be resolved in the order of registration)
+	/// </summary>
+	/// <remarks>
+	/// <para>WARNING: To use these extensions, you need to build the ServiceProvider using <see cref="ServiceProviderFactory"/>.</para>
+	/// </remarks>
+	public static IEnumerable<TServiceType> GetAllServices<TServiceType>(this IServiceProvider serviceProvider)
+	{
+		var keys = serviceProvider.GetService<Keys<TServiceType>>();
+		var serviceList = new List<TServiceType>();
+		// add null key to get all non-keyed services
+		serviceList.AddRange(serviceProvider.GetServices<TServiceType>());
+		if (keys != null)
 		{
-			var keys = serviceProvider.GetService<Keys<TServiceType>>();
-			var serviceList = new List<TServiceType>();
-			// add null key to get all non-keyed services
-			serviceList.AddRange(serviceProvider.GetServices<TServiceType>());
-			if (keys != null)
+			foreach (var serviceKey in keys)
 			{
-				foreach (var serviceKey in keys)
+				var services = serviceProvider.GetKeyedServices<TServiceType>(serviceKey);
+				if (services?.Any() == true)
 				{
-					var services = serviceProvider.GetKeyedServices<TServiceType>(serviceKey);
-					if (services?.Any() == true)
-					{
-						serviceList.AddRange(services!);
-					}
+					serviceList.AddRange(services!);
 				}
 			}
-			return serviceList;
 		}
+		return serviceList;
+	}
 
-		private static InvalidOperationException BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory(Exception? ex = null)
-		{
-			// throw an exception to inform the user he need to build the service provider the proper
-			// way to use these extensions
-			return new InvalidOperationException($"To use these extensions, you need to build the ServiceProvider using: {typeof(ServiceProviderFactory).FullName}.", ex);
-		}
+	private static InvalidOperationException BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory(Exception? ex = null)
+	{
+		// throw an exception to inform the user he need to build the service provider the proper
+		// way to use these extensions
+		return new InvalidOperationException($"To use these extensions, you need to build the ServiceProvider using: {typeof(ServiceProviderFactory).FullName}.", ex);
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.cs
@@ -17,45 +17,6 @@ namespace Mammoth.Extensions.DependencyInjection;
 public static partial class ServiceProviderExtensions
 {
 	/// <summary>
-	/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
-	/// </summary>
-	public static bool IsServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
-	{
-		if (serviceType is null)
-		{
-			throw new ArgumentNullException(nameof(serviceType));
-		}
-		var serviceTypes = serviceProvider.GetService<ServiceTypes>()
-			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
-
-		return serviceTypes.Any(type => type == serviceType);
-	}
-
-	/// <summary>
-	/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
-	/// </summary>
-	public static bool IsServiceRegistered<TServiceType>(this IServiceProvider serviceProvider)
-	{
-		return IsServiceRegistered(serviceProvider, typeof(TServiceType));
-	}
-
-	/// <summary>
-	/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
-	/// </summary>
-	public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
-	{
-		if (serviceKey is null)
-		{
-			throw new ArgumentNullException(nameof(serviceKey));
-		}
-
-		var serviceKeys = serviceProvider.GetService<Keys>()
-			?? throw BuildExceptionBecauseProviderWasNotBuiltUsingTheFactory();
-
-		return serviceKeys.Any(key => key.Equals(serviceKey));
-	}
-
-	/// <summary>
 	/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
 	/// Order of services is not guaranteed to be the same as the order of registration:
 	/// - first will be resolved non-keyed services (in the order of registration)
@@ -67,7 +28,7 @@ public static partial class ServiceProviderExtensions
 	/// </remarks>
 	public static IEnumerable<object?> GetAllServices(this IServiceProvider serviceProvider, Type serviceType)
 	{
-		var KeysType = typeof(Keys<>).MakeGenericType(serviceType);
+		var KeysType = typeof(ServiceKeys<>).MakeGenericType(serviceType);
 		var serviceList = new List<object?>();
 		// add null key to get all non-keyed services
 		serviceList.AddRange(serviceProvider.GetServices(serviceType));
@@ -97,7 +58,7 @@ public static partial class ServiceProviderExtensions
 	/// </remarks>
 	public static IEnumerable<TServiceType> GetAllServices<TServiceType>(this IServiceProvider serviceProvider)
 	{
-		var keys = serviceProvider.GetService<Keys<TServiceType>>();
+		var keys = serviceProvider.GetService<ServiceKeys<TServiceType>>();
 		var serviceList = new List<TServiceType>();
 		// add null key to get all non-keyed services
 		serviceList.AddRange(serviceProvider.GetServices<TServiceType>());

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderFactory.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderFactory.cs
@@ -27,10 +27,23 @@ namespace Mammoth.Extensions.DependencyInjection
 			var dict = new Dictionary<Type, HashSet<object>>();
 			var keys = new Keys();
 			var serviceTypes = new ServiceTypes();
+			var serviceLifetimes = new ServiceLifetimes();
+			var serviceLifetimesByType = new Dictionary<Type, Dictionary<object?, ServiceLifetime>>();
 
 			foreach (var service in containerBuilder)
 			{
 				serviceTypes.Add(service.ServiceType);
+
+				// Track the lifetime for this service
+				serviceLifetimes.Add(service.ServiceType, service.Lifetime, service.ServiceKey);
+
+				// Store lifetime by type and key
+				if (!serviceLifetimesByType.TryGetValue(service.ServiceType, out var lifetimesForType))
+				{
+					lifetimesForType = [];
+					serviceLifetimesByType[service.ServiceType] = lifetimesForType;
+				}
+				lifetimesForType[service.ServiceKey] = service.Lifetime;
 
 				if (service.ServiceKey != null)
 				{
@@ -53,12 +66,24 @@ namespace Mammoth.Extensions.DependencyInjection
 				containerBuilder.AddSingleton(type, svc!);
 			}
 
+			// Insert ServiceLifetimes<ServiceType> as a service
+			foreach (var kvp in serviceLifetimesByType)
+			{
+				var type = typeof(ServiceLifetimes<>).MakeGenericType(kvp.Key);
+				var svc = Activator.CreateInstance(type, kvp.Value);
+				containerBuilder.AddSingleton(type, svc!);
+			}
+
 			// Insert ServiceTypes as a service
 			containerBuilder.AddSingleton(serviceTypes);
 			// Insert Keys as a service
 			containerBuilder.AddSingleton(keys);
 			// Insert Keys<> so it's always resolvable
 			containerBuilder.AddSingleton(typeof(Keys<>));
+			// Insert ServiceLifetimes as a service
+			containerBuilder.AddSingleton(serviceLifetimes);
+			// Insert ServiceLifetimes<> so it's always resolvable
+			containerBuilder.AddSingleton(typeof(ServiceLifetimes<>));
 
 			return containerBuilder.BuildServiceProvider();
 		}
@@ -85,4 +110,64 @@ namespace Mammoth.Extensions.DependencyInjection
 	/// The list of all registered ServiceType.
 	/// </summary>
 	public class ServiceTypes : HashSet<Type>;
+
+	/// <summary>
+	/// Stores the lifetime information for a specific service type with its associated keys.
+	/// </summary>
+	/// <typeparam name="T">The service type.</typeparam>
+	public class ServiceLifetimes<T> : Dictionary<object?, ServiceLifetime>
+	{
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public ServiceLifetimes(Dictionary<object?, ServiceLifetime> lifetimes) : base(lifetimes)
+		{ }
+	}
+
+	/// <summary>
+	/// Tracks the lifetime of all registered services.
+	/// </summary>
+	public class ServiceLifetimes
+	{
+		private readonly Dictionary<Type, Dictionary<object?, ServiceLifetime>> _lifetimes = [];
+
+		/// <summary>
+		/// Adds a service type with its lifetime and optional key.
+		/// </summary>
+		/// <param name="serviceType">The type of the service.</param>
+		/// <param name="lifetime">The lifetime of the service.</param>
+		/// <param name="serviceKey">The optional key for the service.</param>
+		public void Add(Type serviceType, ServiceLifetime lifetime, object? serviceKey = null)
+		{
+			if (!_lifetimes.TryGetValue(serviceType, out var lifetimesByKey))
+			{
+				lifetimesByKey = [];
+				_lifetimes[serviceType] = lifetimesByKey;
+			}
+
+			lifetimesByKey[serviceKey] = lifetime;
+		}
+
+		/// <summary>
+		/// Gets the lifetime for a specific service type and optional key.
+		/// </summary>
+		/// <param name="serviceType">The type of the service.</param>
+		/// <param name="serviceKey">The optional key for the service.</param>
+		/// <returns>The lifetime of the service or null if not found.</returns>
+		public ServiceLifetime? GetLifetime(Type serviceType, object? serviceKey = null)
+		{
+			if (_lifetimes.TryGetValue(serviceType, out var lifetimesByKey) &&
+				lifetimesByKey.TryGetValue(serviceKey, out var lifetime))
+			{
+				return lifetime;
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Gets all service types with their associated lifetimes.
+		/// </summary>
+		public IReadOnlyDictionary<Type, Dictionary<object?, ServiceLifetime>> GetAllLifetimes() => _lifetimes;
+	}
 }


### PR DESCRIPTION
Added the following extension methods:

- `GetAllServices`: resolves all keyed and non-keyed services of a given service type.
- `IsServiceRegistered`: checks whether the specified service type is registered in the service provider (keyed or non-keyed).
- `IsKeyedServiceRegistered`: checks whether the specified service type is registered as keyed in the service provider.
- `IsTransientServiceRegistered`: checks whether the specified service type is registered as transient in the service provider (non keyed services).
- `IsScopedServiceRegistered`: checks whether the specified service type is registered as scoped in the service provider (non keyed services).
- `IsSingletonServiceRegistered`: checks whether the specified service type is registered as singleton in the service provider (non keyed services).
- `IsKeyedTransientServiceRegistered`: checks whether the specified service type is registered as transient in the service provider (keyed services).
- `IsKeyedScopedServiceRegistered`: checks whether the specified service type is registered as scoped in the service provider (keyed services).
- `IsKeyedSingletonServiceRegistered`: checks whether the specified service type is registered as singleton in the service provider (keyed services).