### PR TITLE
Refs: #5 Add detection for transient disposable service misuse

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Detect incorrect usage of Transient Disposable services: resolving a transient disposable result in a memory leak [#5](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/5).
+
 ## 0.4.0
 
 - Added ServiceProvider extension methods to check if Registered Services are: Transient, Scoped, Singleton [#1](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/1)

--- a/README.md
+++ b/README.md
@@ -139,17 +139,34 @@ Helper methods to check if a service was registered or a ServiceDescriptor exist
 
 To use the following extensions you need to build the ServiceProvider using our `ServiceProviderFactory`.
 
-It will inject some support services that are used to keep tracks of the registered services.
+It will inject support services used to detect incorrect usage of Transient Disposable services and keep track of registered services.
 
 ```csharp
-new HostBuilder().UseServiceProviderFactory(new ServiceProviderFactory());
+new HostBuilder().UseServiceProviderFactory(new ServiceProviderFactory(new ExtendedServiceProviderOptions()));
 
 // - or -
 
-var serviceProvider = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+var serviceProvider = ServiceProviderFactory.CreateServiceProvider(serviceCollection, new ExtendedServiceProviderOptions());
 ```
 
-You can then use the following extensions:
+###### Detect incorrect usage of Transient Disposables
+
+To detect incorrect usage of Transient Disposable when they are resolved by Root Scope, create the service provider with:
+
+```csharp
+new HostBuilder().UseServiceProviderFactory(new ServiceProviderFactory(
+  new ExtendedServiceProviderOptions 
+  {
+    DetectIncorrectUsageOfTransientDisposables = true 
+  }));
+```
+
+WARNING: use this feature only in debug and development build, because it has a performance impact and internally uses reflection to 
+access internal Service Provider implementation (it can be fragile).
+
+###### IsRegistered extension methods
+
+You can use the following `IServiceProvider` extension methods:
 
 - `GetAllServices`: resolves all keyed and non-keyed services of a given service type.
 - `IsServiceRegistered`: checks whether the specified service type is registered in the service provider (keyed or non-keyed).

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
@@ -1,0 +1,191 @@
+﻿using Mammoth.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mammoth.Extensions.DependencyInjection.Tests
+{
+	// Transient disposables objects are captured by the container and disposed (and released) when the
+	// scope is disposed.
+	// If such services are resolved by the root scope, they will never be released until the container is disposed
+	// (this will result in a memory leak).
+	// The same goes for scoped services.
+
+	[TestClass]
+	public class DetectIncorrectUsageOfTransientDisposablesTests
+	{
+		public class TransientDisposable : IDisposable
+		{
+			public void Dispose()
+			{
+				GC.SuppressFinalize(this);
+			}
+		}
+
+		public class Consumer
+		{
+			public TransientDisposable TransientDisposable { get; }
+
+			public Consumer(TransientDisposable transientDisposable)
+			{
+				TransientDisposable = transientDisposable;
+			}
+		}
+
+		[TestMethod]
+		public void ServiceProvider_IsRootScope_True()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			using var sp = serviceCollection.BuildServiceProvider();
+
+			Assert.IsTrue(sp.GetIsRootScope());
+		}
+
+		[TestMethod]
+		public void ScopeServiceProvider_IsRootScope_False()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			using var sp = serviceCollection.BuildServiceProvider();
+			using var scope = sp.CreateScope();
+			Assert.IsFalse(scope.ServiceProvider.GetIsRootScope());
+		}
+
+		[TestMethod]
+		public void Resolve_TransientDisposable_InRootScope_MemoryLeak()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			using var sp = serviceCollection.BuildServiceProvider();
+			var transient = sp.GetService<TransientDisposable>();
+			Assert.IsNotNull(transient);
+			// check for memory leaks: the "transient" object will never be held by internal sp.Disables array property until the container is disposed
+			Assert.IsTrue(sp.GetIsRootScope());
+			var disposables = sp.GetDisposables();
+			Assert.AreEqual(1, disposables.Count());
+			Assert.IsTrue(disposables.Contains(transient));
+		}
+
+		[TestMethod]
+		public void Resolve_Consumer_InRootScope_MemoryLeak()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			serviceCollection.AddTransient<Consumer>();
+			using var sp = serviceCollection.BuildServiceProvider();
+			var consumer = sp.GetService<Consumer>();
+			Assert.IsNotNull(consumer);
+			// check for memory leaks: the "transient" object will never be held by internal sp.Disables array property until the container is disposed
+			Assert.IsTrue(sp.GetIsRootScope());
+			var disposables = sp.GetDisposables();
+			Assert.AreEqual(1, disposables.Count());
+			Assert.IsTrue(disposables.Contains(consumer.TransientDisposable));
+		}
+
+		[TestMethod]
+		public void Resolve_TransientDisposable_InScope_NoMemoryLeak()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			using var sp = serviceCollection.BuildServiceProvider();
+
+			using var scope = sp.CreateScope();
+			var consumer = scope.ServiceProvider.GetService<TransientDisposable>();
+			Assert.IsNotNull(consumer);
+			Assert.IsFalse(scope.ServiceProvider.GetIsRootScope());
+			Assert.IsTrue(scope.ServiceProvider.GetDisposables().Contains(consumer));
+			Assert.IsTrue(sp.GetIsRootScope());
+			Assert.IsFalse(sp.GetDisposables().Contains(consumer));
+		}
+
+		[TestMethod]
+		public void Resolve_Consumer_InScope_NoMemoryLeak()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			serviceCollection.AddTransient<Consumer>();
+			using var sp = serviceCollection.BuildServiceProvider();
+
+			using var scope = sp.CreateScope();
+			var consumer = scope.ServiceProvider.GetService<Consumer>();
+			Assert.IsNotNull(consumer);
+			Assert.IsFalse(scope.ServiceProvider.GetIsRootScope());
+			Assert.IsTrue(scope.ServiceProvider.GetDisposables().Contains(consumer.TransientDisposable));
+			Assert.IsTrue(sp.GetIsRootScope());
+			Assert.IsFalse(sp.GetDisposables().Contains(consumer));
+		}
+
+		[TestMethod]
+		public void Resolve_TransientDisposable_InRootScope_WithValidation_Throws()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetService<TransientDisposable>());
+		}
+
+		[TestMethod]
+		public void Resolve_Consumer_InRootScope_WithValidation_Throws()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			serviceCollection.AddTransient<Consumer>();
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetService<Consumer>());
+		}
+
+		[TestMethod]
+		public void Resolve_TransientDisposable_InScope_WithValidation_NoMemoryLeak()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			using var scope = sp.CreateScope();
+			var consumer = scope.ServiceProvider.GetService<TransientDisposable>();
+			Assert.IsNotNull(consumer);
+			Assert.IsFalse(scope.ServiceProvider.GetIsRootScope());
+			Assert.IsTrue(scope.ServiceProvider.GetDisposables().Contains(consumer));
+			Assert.IsTrue(sp.GetIsRootScope());
+			Assert.IsFalse(sp.GetDisposables().Contains(consumer));
+		}
+
+		[TestMethod]
+		public void Resolve_Consumer_InScope_WithValidation_NoMemoryLeak()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientDisposable>();
+			serviceCollection.AddTransient<Consumer>();
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			using var scope = sp.CreateScope();
+			var consumer = scope.ServiceProvider.GetService<Consumer>();
+			Assert.IsNotNull(consumer);
+			Assert.IsFalse(scope.ServiceProvider.GetIsRootScope());
+			Assert.IsTrue(scope.ServiceProvider.GetDisposables().Contains(consumer.TransientDisposable));
+			Assert.IsTrue(sp.GetIsRootScope());
+			Assert.IsFalse(sp.GetDisposables().Contains(consumer));
+		}
+	}
+}

--- a/src/Mammoth.Extensions.DependencyInjection/AssemblyInfo.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Mammoth.Extensions.DependencyInjection.Tests")]

--- a/src/Mammoth.Extensions.DependencyInjection/DetectIncorrectUsageOfTransientDisposables.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/DetectIncorrectUsageOfTransientDisposables.cs
@@ -1,0 +1,127 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Mammoth.Extensions.DependencyInjection
+{
+	/// <summary>
+	/// original code took from blazor-samples:
+	/// https://github.com/dotnet/blazor-samples/blob/main/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
+	/// </summary>
+	internal static class DetectIncorrectUsageOfTransientDisposables
+	{
+		/// <summary>
+		/// Create a new "patched" service collection that will throw an exception if a transient disposable service is resolved in the root scope.
+		/// </summary>
+		public static IServiceCollection PatchServiceCollection(IServiceCollection containerBuilder)
+		{
+			var collection = new ServiceCollection();
+
+			foreach (var descriptor in containerBuilder)
+			{
+				switch (descriptor.Lifetime)
+				{
+					case ServiceLifetime.Transient
+						when (descriptor is { IsKeyedService: true, KeyedImplementationType: not null }
+							&& typeof(IDisposable).IsAssignableFrom(descriptor.KeyedImplementationType))
+							|| (descriptor is { IsKeyedService: false, ImplementationType: not null }
+								&& typeof(IDisposable).IsAssignableFrom(descriptor.ImplementationType)):
+						collection.Add(CreatePatchedDescriptor(descriptor));
+						break;
+					case ServiceLifetime.Transient
+						when descriptor is { IsKeyedService: true, KeyedImplementationFactory: not null }:
+						collection.Add(CreatePatchedKeyedFactoryDescriptor(descriptor));
+						break;
+					case ServiceLifetime.Transient
+						when descriptor is { IsKeyedService: false, ImplementationFactory: not null }:
+						collection.Add(CreatePatchedFactoryDescriptor(descriptor));
+						break;
+					default:
+						collection.Add(descriptor);
+						break;
+				}
+			}
+
+			return collection;
+		}
+
+		private static ServiceDescriptor CreatePatchedFactoryDescriptor(
+			ServiceDescriptor original)
+		{
+			var newDescriptor = new ServiceDescriptor(
+				original.ServiceType,
+				(sp) =>
+				{
+					var originalFactory = original.ImplementationFactory ??
+						throw new InvalidOperationException("originalFactory is null.");
+
+					var originalResult = originalFactory(sp);
+
+					if (sp.GetIsRootScope() && originalResult is IDisposable d)
+					{
+						ThrowTransientDisposableException(d.GetType().Name);
+					}
+
+					return originalResult;
+				},
+				ServiceLifetime.Transient);
+
+			return newDescriptor;
+		}
+
+		private static ServiceDescriptor CreatePatchedKeyedFactoryDescriptor(ServiceDescriptor original)
+		{
+			var newDescriptor = new ServiceDescriptor(
+				original.ServiceType,
+				original.ServiceKey,
+				(sp, obj) =>
+				{
+					var originalFactory = original.KeyedImplementationFactory ??
+										  throw new InvalidOperationException("KeyedImplementationFactory is null.");
+
+					var originalResult = originalFactory(sp, obj);
+
+					if (sp.GetIsRootScope() && originalResult is IDisposable d)
+					{
+						ThrowTransientDisposableException(d.GetType().Name);
+					}
+
+					return originalResult;
+				},
+				ServiceLifetime.Transient);
+
+			return newDescriptor;
+		}
+
+		private static ServiceDescriptor CreatePatchedDescriptor(
+			ServiceDescriptor original)
+		{
+			var newDescriptor = new ServiceDescriptor(
+				original.ServiceType,
+				(sp) =>
+				{
+					if (sp.GetIsRootScope())
+					{
+						ThrowTransientDisposableException(original.ImplementationType?.Name);
+					}
+
+					if (original.ImplementationType is null)
+					{
+						throw new InvalidOperationException(
+							"ImplementationType is null.");
+					}
+
+					return ActivatorUtilities.CreateInstance(sp,
+						original.ImplementationType);
+				},
+				ServiceLifetime.Transient);
+
+			return newDescriptor;
+		}
+
+		private static void ThrowTransientDisposableException(string? typeName)
+		{
+			throw new InvalidOperationException(
+				$"Trying to resolve transient disposable service {typeName} in the wrong scope (root scope).");
+		}
+	}
+}

--- a/src/Mammoth.Extensions.DependencyInjection/ExtendedServiceProviderOptions.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ExtendedServiceProviderOptions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Mammoth.Extensions.DependencyInjection
+{
+	/// <summary>
+	/// Extends ServiceProviderOptions:
+	/// - Include a property for detecting incorrect usage of transient disposables.
+	///   This helps ensure proper resource management and avoid memory leaks
+	/// </summary>
+	public class ExtendedServiceProviderOptions : ServiceProviderOptions
+	{
+		/// <summary>
+		/// <para>
+		/// Indicates whether incorrect usage of transient disposables is detected.
+		/// If set to true, the service provider will throw an exception if a transient disposable is resolved from the root scope.
+		/// </para>
+		/// <para>
+		/// WARNING: use this setting only in debug build as it "patches" the service collection and uses
+		/// reflection to access internal properties of the service provider.
+		/// </para>
+		/// </summary>
+		public bool DetectIncorrectUsageOfTransientDisposables { get; set; }
+	}
+}

--- a/src/Mammoth.Extensions.DependencyInjection/Mammoth.Extensions.DependencyInjection.csproj
+++ b/src/Mammoth.Extensions.DependencyInjection/Mammoth.Extensions.DependencyInjection.csproj
@@ -24,10 +24,10 @@
 		<AnalysisLevel>latest-recommended</AnalysisLevel>
 	</PropertyGroup>
 	<ItemGroup>
-	  <Compile Remove="ServiceProviderExtensions.Reflection.cs" />
+	  <Compile Remove="ServiceProviderExtensions.Reflection.Disabled.cs" />
 	</ItemGroup>
 	<ItemGroup>
-	  <None Include="ServiceProviderExtensions.Reflection.cs" />
+	  <None Include="ServiceProviderExtensions.Reflection.Disabled.cs" />
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<None Include="..\..\Mammoth.png" Pack="true" PackagePath="\" />
 	</ItemGroup>

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Reflection.Disabled.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Reflection.Disabled.cs
@@ -1,0 +1,151 @@
+﻿// deprecated
+
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Mammoth.Extensions.DependencyInjection
+{
+	// Instead of using reflection to access internal properties of the service provider, consider using the following approach:
+	// Resolve all services: another approach to consider is "enumerate all keys": https://github.com/dotnet/runtime/issues/91466#issuecomment-1723532096
+	// We can create a custom factory provider that will register some structure with all the
+	// information needed to know what services are registered (like service type, service key, etc).
+	// we can then use these structures to resolve all services.
+	// This approach is more reliable and less likely to break in future versions of the framework.
+
+	// These extension methods were disabled in favor of those that use the ServiceProviderFactory approach.
+
+	/// <summary>
+	/// Provides extension methods for <see cref="IServiceProvider"/>.
+	/// </summary>
+	public static class ServiceProviderExtensions
+	{
+		/// <summary>
+		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+		/// </summary>
+		/// <remarks>
+		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
+		/// </remarks>
+		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+		{
+			if (serviceType is null)
+			{
+				throw new ArgumentNullException(nameof(serviceType));
+			}
+
+			var descriptors = GetServiceDescriptors(serviceProvider);
+			return descriptors?.Any(sd => sd.ServiceType == serviceType) ?? false;
+		}
+
+		/// <summary>
+		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+		/// </summary>
+		/// <remarks>
+		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
+		/// </remarks>
+		public static bool IsServiceRegistered<TService>(this IServiceProvider serviceProvider)
+		{
+			return IsServiceRegistered(serviceProvider, typeof(TService));
+		}
+
+		/// <summary>
+		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+		/// </summary>
+		/// <remarks>
+		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
+		/// </remarks>
+		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
+		{
+			if (serviceKey is null)
+			{
+				throw new ArgumentNullException(nameof(serviceKey));
+			}
+
+			var descriptors = GetServiceDescriptors(serviceProvider);
+			return descriptors?.Any(sd => sd.ServiceKey?.Equals(serviceKey) == true) ?? false;
+		}
+
+		/// <summary>
+		/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
+		/// </summary>
+		/// <remarks>
+		/// <para>WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.</para>
+		/// <para>WARNING: It might be removed once enumerating all services with KeyedService.AnyKey work as expected.</para>
+		/// </remarks>
+		public static IEnumerable<object> GetAllServices(this IServiceProvider serviceProvider, Type serviceType)
+		{
+			var descriptors = GetServiceDescriptors(serviceProvider);
+			if (descriptors == null)
+			{
+				return Enumerable.Empty<object>();
+			}
+			// find out all the unique services keyed names
+			var serviceKeys = descriptors
+				.Where(sd => sd.ServiceType == serviceType)
+				.Select(sd => sd.ServiceKey)
+				.Distinct()
+				.ToList();
+			var serviceList = new List<object>();
+			// null key to get all non-keyed services
+			foreach (var serviceKey in serviceKeys)
+			{
+				var services = serviceProvider.GetKeyedServices(serviceType, serviceKey);
+				if (services?.Any() == true)
+				{
+					serviceList.AddRange(services!);
+				}
+			}
+			return serviceList;
+		}
+
+		/// <summary>
+		/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
+		/// </summary>
+		/// <remarks>
+		/// <para>WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.</para>
+		/// <para>WARNING: It might be removed once enumerating all services with KeyedService.AnyKey work as expected.</para>
+		/// </remarks>
+		public static IEnumerable<TService> GetAllServices<TService>(this IServiceProvider serviceProvider)
+		{
+			var descriptors = GetServiceDescriptors(serviceProvider);
+			if (descriptors == null)
+			{
+				return Enumerable.Empty<TService>();
+			}
+			// find out all the unique services keyed names
+			var serviceKeys = descriptors
+				.Where(sd => sd.ServiceType == typeof(TService))
+				.Select(sd => sd.ServiceKey)
+				.Distinct()
+				.ToList();
+			var serviceList = new List<TService>();
+			// null key to get all non-keyed services
+			foreach (var serviceKey in serviceKeys)
+			{
+				var services = serviceProvider.GetKeyedServices<TService>(serviceKey);
+				if (services?.Any() == true)
+				{
+					serviceList.AddRange(services!);
+				}
+			}
+			return serviceList;
+		}
+
+		private static IEnumerable<ServiceDescriptor> GetServiceDescriptors(IServiceProvider serviceProvider)
+		{
+			var callSiteFactoryProperty = serviceProvider.GetType().GetProperty("CallSiteFactory", BindingFlags.NonPublic | BindingFlags.Instance);
+			if (callSiteFactoryProperty != null)
+			{
+				var callSiteFactory = callSiteFactoryProperty.GetValue(serviceProvider);
+				var serviceDescriptorsProperty = callSiteFactory?.GetType().GetProperty("Descriptors", BindingFlags.NonPublic | BindingFlags.Instance);
+				if (serviceDescriptorsProperty != null)
+				{
+					return (IEnumerable<ServiceDescriptor>)serviceDescriptorsProperty.GetValue(callSiteFactory);
+				}
+			}
+			throw new InvalidOperationException("Internal implementation of ServiceProvider changed, cannot enumerate service descriptors.");
+		}
+	}
+}

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Reflection.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderExtensions.Reflection.cs
@@ -1,151 +1,91 @@
-﻿// deprecated
-
-using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Mammoth.Extensions.DependencyInjection
 {
-	// Instead of using reflection to access internal properties of the service provider, consider using the following approach:
-	// Resolve all services: another approach to consider is "enumerate all keys": https://github.com/dotnet/runtime/issues/91466#issuecomment-1723532096
-	// We can create a custom factory provider that will register some structure with all the
-	// information needed to know what services are registered (like service type, service key, etc).
-	// we can then use these structures to resolve all services.
-	// This approach is more reliable and less likely to break in future versions of the framework.
-
-	// These extension methods were disabled in favor of those that use the ServiceProviderFactory approach.
-
 	/// <summary>
-	/// Provides extension methods for <see cref="IServiceProvider"/>.
+	/// Provides extension methods for IServiceProvider to access internal properties.
+	/// Includes methods to retrieve the IsScope property and Disposables collection.
 	/// </summary>
-	public static class ServiceProviderExtensions
+	public static partial class ServiceProviderExtensions
 	{
 		/// <summary>
-		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+		/// Retrieves the service provider from a given instance, potentially accessing a private 'Root' property.
+		/// This is a very fragile way to obtain internal service provider implementation detail for testing purposes.
+		/// Look at the internal ServiceProvider implementation:
+		/// https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
 		/// </summary>
-		/// <remarks>
-		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
-		/// </remarks>
-		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, Type serviceType)
+		/// <returns>Returns the service provider, which may be the original or the root service provider if accessible.</returns>
+		private static IServiceProvider GetServiceProviderEngineScope(IServiceProvider serviceProvider)
 		{
-			if (serviceType is null)
+			var sp = serviceProvider;
+			var rootProperty = serviceProvider.GetType().GetProperty("Root",
+				BindingFlags.NonPublic | BindingFlags.Instance);
+			if (rootProperty != null)
 			{
-				throw new ArgumentNullException(nameof(serviceType));
+				sp = (IServiceProvider)rootProperty.GetValue(serviceProvider)!;
 			}
-
-			var descriptors = GetServiceDescriptors(serviceProvider);
-			return descriptors?.Any(sd => sd.ServiceType == serviceType) ?? false;
+			return sp;
 		}
 
 		/// <summary>
-		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+		/// Gets the value of the internal IsScope property from a ServiceProvider
 		/// </summary>
-		/// <remarks>
-		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
-		/// </remarks>
-		public static bool IsServiceRegistered<TService>(this IServiceProvider serviceProvider)
+		internal static bool GetIsRootScope(this IServiceProvider serviceProvider)
 		{
-			return IsServiceRegistered(serviceProvider, typeof(TService));
+			// if it has a Root "property" that will be the root scope (an instance of ServiceProviderEngineScope)
+			// otherwise it's already an instance of ServiceProviderEngineScope and it's a scope.
+			var sp = GetServiceProviderEngineScope(serviceProvider);
+
+			// Get the IsScope property using reflection
+			var isScopeProperty = sp.GetType().GetProperty("IsRootScope",
+				BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+			if (isScopeProperty != null)
+			{
+				return (bool)isScopeProperty.GetValue(sp);
+			}
+
+			throw new InvalidOperationException("Internal implementation of ServiceProvider changed: cannot access IsRootScope property.");
 		}
 
 		/// <summary>
-		/// Determines whether the specified service type is registered in the service provider (keyed or non-keyed).
+		/// Gets the internal Disposables collection from a ServiceProvider
 		/// </summary>
-		/// <remarks>
-		/// WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.
-		/// </remarks>
-		public static bool IsServiceRegistered(this IServiceProvider serviceProvider, object serviceKey)
+		internal static IEnumerable<object> GetDisposables(this IServiceProvider serviceProvider)
 		{
-			if (serviceKey is null)
-			{
-				throw new ArgumentNullException(nameof(serviceKey));
-			}
+			// if it has a Root "property" that will be the root scope (an instance of ServiceProviderEngineScope)
+			// otherwise it's already an instance of ServiceProviderEngineScope and it's a scope.
+			var sp = GetServiceProviderEngineScope(serviceProvider);
 
-			var descriptors = GetServiceDescriptors(serviceProvider);
-			return descriptors?.Any(sd => sd.ServiceKey?.Equals(serviceKey) == true) ?? false;
-		}
+			/*
+			// Get the Disposables field using reflection
+			var disposablesField = sp.GetType().GetField("_disposables",
+				BindingFlags.NonPublic | BindingFlags.Instance);
 
-		/// <summary>
-		/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
-		/// </summary>
-		/// <remarks>
-		/// <para>WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.</para>
-		/// <para>WARNING: It might be removed once enumerating all services with KeyedService.AnyKey work as expected.</para>
-		/// </remarks>
-		public static IEnumerable<object> GetAllServices(this IServiceProvider serviceProvider, Type serviceType)
-		{
-			var descriptors = GetServiceDescriptors(serviceProvider);
-			if (descriptors == null)
+			if (disposablesField != null)
 			{
-				return Enumerable.Empty<object>();
-			}
-			// find out all the unique services keyed names
-			var serviceKeys = descriptors
-				.Where(sd => sd.ServiceType == serviceType)
-				.Select(sd => sd.ServiceKey)
-				.Distinct()
-				.ToList();
-			var serviceList = new List<object>();
-			// null key to get all non-keyed services
-			foreach (var serviceKey in serviceKeys)
-			{
-				var services = serviceProvider.GetKeyedServices(serviceType, serviceKey);
-				if (services?.Any() == true)
+				var disposables = disposablesField.GetValue(sp);
+				if (disposables is IEnumerable<object> disposablesList)
 				{
-					serviceList.AddRange(services!);
+					return disposablesList;
 				}
 			}
-			return serviceList;
-		}
+			*/
 
-		/// <summary>
-		/// Resolves all the services of the specified ServiceTye (both keyed and non-keyed) from the service provider.
-		/// </summary>
-		/// <remarks>
-		/// <para>WARNING: it uses reflection to access internal properties of the service provider, so it may break in future versions of the framework.</para>
-		/// <para>WARNING: It might be removed once enumerating all services with KeyedService.AnyKey work as expected.</para>
-		/// </remarks>
-		public static IEnumerable<TService> GetAllServices<TService>(this IServiceProvider serviceProvider)
-		{
-			var descriptors = GetServiceDescriptors(serviceProvider);
-			if (descriptors == null)
+			// Check alternative field names (since internal implementation might vary)
+			var disposablesField = sp.GetType().GetProperty("Disposables",
+				BindingFlags.NonPublic | BindingFlags.Instance);
+
+			if (disposablesField != null)
 			{
-				return Enumerable.Empty<TService>();
-			}
-			// find out all the unique services keyed names
-			var serviceKeys = descriptors
-				.Where(sd => sd.ServiceType == typeof(TService))
-				.Select(sd => sd.ServiceKey)
-				.Distinct()
-				.ToList();
-			var serviceList = new List<TService>();
-			// null key to get all non-keyed services
-			foreach (var serviceKey in serviceKeys)
-			{
-				var services = serviceProvider.GetKeyedServices<TService>(serviceKey);
-				if (services?.Any() == true)
+				var disposables = disposablesField.GetValue(sp);
+				if (disposables is IEnumerable<object> disposablesList)
 				{
-					serviceList.AddRange(services!);
+					return disposablesList;
 				}
 			}
-			return serviceList;
-		}
 
-		private static IEnumerable<ServiceDescriptor> GetServiceDescriptors(IServiceProvider serviceProvider)
-		{
-			var callSiteFactoryProperty = serviceProvider.GetType().GetProperty("CallSiteFactory", BindingFlags.NonPublic | BindingFlags.Instance);
-			if (callSiteFactoryProperty != null)
-			{
-				var callSiteFactory = callSiteFactoryProperty.GetValue(serviceProvider);
-				var serviceDescriptorsProperty = callSiteFactory?.GetType().GetProperty("Descriptors", BindingFlags.NonPublic | BindingFlags.Instance);
-				if (serviceDescriptorsProperty != null)
-				{
-					return (IEnumerable<ServiceDescriptor>)serviceDescriptorsProperty.GetValue(callSiteFactory);
-				}
-			}
-			throw new InvalidOperationException("Internal implementation of ServiceProvider changed, cannot enumerate service descriptors.");
+			throw new InvalidOperationException("Internal implementation of ServiceProvider changed: cannot access Disposable property.");
 		}
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceProviderFactory.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceProviderFactory.cs
@@ -22,7 +22,26 @@ namespace Mammoth.Extensions.DependencyInjection
 		/// Enrich the <paramref name="containerBuilder"/> with the necessary services to be able to resolve the keys
 		/// and other useful services; then build the <see cref="IServiceProvider"/>.
 		/// </summary>
-		public static IServiceProvider CreateServiceProvider(IServiceCollection containerBuilder)
+		public static ServiceProvider CreateServiceProvider(IServiceCollection containerBuilder, ExtendedServiceProviderOptions? options = null)
+		{
+			AddIsRegisteredSupportServices(containerBuilder);
+
+			if (options == null)
+			{
+				return containerBuilder.BuildServiceProvider();
+			}
+			var sc = containerBuilder;
+			if (options.DetectIncorrectUsageOfTransientDisposables)
+			{
+				sc = DetectIncorrectUsageOfTransientDisposables.PatchServiceCollection(containerBuilder);
+			}
+			return sc.BuildServiceProvider(options);
+		}
+
+		/// <summary>
+		/// Registers support services related to service keys, types, and lifetimes in the provided service collection.
+		/// </summary>
+		private static void AddIsRegisteredSupportServices(IServiceCollection containerBuilder)
 		{
 			var dict = new Dictionary<Type, HashSet<object>>();
 			var keys = new ServiceKeys();
@@ -67,8 +86,6 @@ namespace Mammoth.Extensions.DependencyInjection
 			containerBuilder.AddSingleton(typeof(ServiceKeys<>));
 			// Insert ServiceLifetimes as a service
 			containerBuilder.AddSingleton(serviceLifetimes);
-
-			return containerBuilder.BuildServiceProvider();
 		}
 	}
 


### PR DESCRIPTION
- Updated `Changelog.md` to document new feature for detecting incorrect usage of transient disposable services.
- Enhanced `README.md` to clarify the role of `ServiceProviderFactory` in tracking transient disposables.
- Introduced `DetectIncorrectUsageOfTransientDisposablesTests` for validating transient disposable behavior and preventing memory leaks.
- Added `InternalsVisibleTo` attribute in `AssemblyInfo.cs` for test project access to internal members.
- Implemented detection logic in `DetectIncorrectUsageOfTransientDisposables.cs` to throw exceptions for root scope resolutions.
- Created `ExtendedServiceProviderOptions` to extend service provider options with detection capabilities.
- Disabled reflection-based service provider extensions in `Mammoth.Extensions.DependencyInjection.csproj`.
- Deprecated `ServiceProviderExtensions.Reflection.cs` in favor of a more reliable approach.
- Updated `ServiceProviderFactory.cs` to utilize `ExtendedServiceProviderOptions` for service provider creation.
- Modified `ServiceProviderExtensions.cs` to include methods for accessing internal properties with caution.