### PR TITLE
Fix: #13 Fix filter composition in AssemblyInspector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### BugFix
+
+- AssemblyInspector does not allow for proper filter composition [#13](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/13)
+
 ## 0.5.7
 
 - added support for .NET 8.0 and .NET 9.0 (previously only netstandard2.0 was supported).

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/AssemblyInspectorTests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/AssemblyInspectorTests.cs
@@ -155,7 +155,7 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		{
 			Assert.ThrowsExactly<NotSupportedException>(() =>
 			{
-				var descriptors = new AssemblyInspector()
+				new AssemblyInspector()
 					.FromAssemblyContaining<ITestService>()
 					.If(t => t.Name == nameof(NestedTransientService1))
 					.If(t => t.Name == nameof(NestedTransientService2))
@@ -256,5 +256,234 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			Assert.IsNull(descriptor.KeyedImplementationType);
 			Assert.IsNotNull(descriptor.KeyedImplementationFactory);
 		}
+
+		#region Filter Composition Tests
+
+		[TestMethod]
+		public void ServiceDescriptors_BasedOn_And_If_WithServiceSelf()
+		{
+			// Test composition of BasedOn and If filters
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.BasedOn<ITestService>()
+				.If(t => t.Name.Contains("Decorator"))
+				.WithServiceSelf()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(3, descriptors.Count());
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(TestServiceDecorator1)
+				&& d.ImplementationType == typeof(TestServiceDecorator1)));
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(TestServiceDecorator2)
+				&& d.ImplementationType == typeof(TestServiceDecorator2)));
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(TestServiceDecorator3)
+				&& d.ImplementationType == typeof(TestServiceDecorator3)));
+			// Should not include TestService or AnotherTestService because they don't contain "Decorator"
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(TestService)));
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(AnotherTestService)));
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_InSameNamespaceAs_And_If_WithServiceSelf()
+		{
+			// Test composition of InSameNamespaceAs and If filters
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.InSameNamespaceAs<NestedTransientService1>()
+				.If(t =>
+#if NET8_0_OR_GREATER
+					t.Name.EndsWith('1')
+#else
+					t.Name.EndsWith("1")
+#endif
+				)
+				.WithServiceSelf()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(1, descriptors.Count());
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(NestedTransientService1)
+				&& d.ImplementationType == typeof(NestedTransientService1)));
+			// Should not include NestedTransientService2 because it doesn't end with "1"
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(NestedTransientService2)));
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_InSameNamespaceAs_IncludeSubNamespaces_And_If_WithServiceSelf()
+		{
+			// Test composition of InSameNamespaceAs with sub-namespaces and If filters
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.InSameNamespaceAs<NestedTransientService1>(includeSubNamespaces: true)
+				.If(t =>
+#if NET8_0_OR_GREATER
+					t.Name.EndsWith('1')
+#else
+					t.Name.EndsWith("1")
+#endif
+				)
+				.WithServiceSelf()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(2, descriptors.Count());
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(NestedTransientService1)
+				&& d.ImplementationType == typeof(NestedTransientService1)));
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(SubNamespaceTransientService1)
+				&& d.ImplementationType == typeof(SubNamespaceTransientService1)));
+			// Should not include NestedTransientService2 because it doesn't end with "1"
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(NestedTransientService2)));
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_BasedOn_And_If_Excludes_NonMatching_Types()
+		{
+			// Verify that filter composition properly excludes types that match one filter but not the other
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.BasedOn<ITestService>()
+				.If(t => t.Name == "TestService")
+				.WithServiceSelf()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(1, descriptors.Count());
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(TestService)
+				&& d.ImplementationType == typeof(TestService)));
+			// Should not include decorators even though they implement ITestService
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(TestServiceDecorator1)));
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(TestServiceDecorator2)));
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(TestServiceDecorator3)));
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(AnotherTestService)));
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_InSameNamespaceAs_And_If_Returns_Empty_When_No_Matches()
+		{
+			// Verify that filter composition returns empty when no types match all filters
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.InSameNamespaceAs<NestedTransientService1>()
+				.If(t => t.Name == "NonExistentType")
+				.WithServiceSelf()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(0, descriptors.Count());
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_BasedOn_And_If_WithServiceBase()
+		{
+			// Test filter composition with WithServiceBase strategy
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.BasedOn<ITestService>()
+				.If(t => t.Name.StartsWith("Test") && !t.Name.Contains("Decorator"))
+				.WithServiceBase()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(1, descriptors.Count());
+			var descriptor = descriptors.Single();
+			Assert.AreEqual(typeof(ITestService), descriptor.ServiceType);
+			Assert.AreEqual(typeof(TestService), descriptor.ImplementationType);
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_BasedOn_And_If_WithServiceAllInterfaces()
+		{
+			// Test filter composition with WithServiceAllInterfaces strategy
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.BasedOn<ITestService>()
+				.If(t => t.Name == "TestService" || t.Name == "AnotherTestService")
+				.WithServiceAllInterfaces()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(4, descriptors.Count());
+			// Should have ITestService for both TestService and AnotherTestService
+			var iTestServiceDescriptors = descriptors.Where(d => d.ServiceType == typeof(ITestService)).ToArray();
+			Assert.AreEqual(2, iTestServiceDescriptors.Length);
+			Assert.IsTrue(iTestServiceDescriptors.Any(d => d.ImplementationType == typeof(TestService)));
+			Assert.IsTrue(iTestServiceDescriptors.Any(d => d.ImplementationType == typeof(AnotherTestService)));
+			// Should also have IAnotherInterface for both
+			var iAnotherInterfaceDescriptors = descriptors.Where(d => d.ServiceType == typeof(IAnotherInterface)).ToArray();
+			Assert.AreEqual(2, iAnotherInterfaceDescriptors.Length);
+			Assert.IsTrue(iAnotherInterfaceDescriptors.Any(d => d.ImplementationType == typeof(TestService)));
+			Assert.IsTrue(iAnotherInterfaceDescriptors.Any(d => d.ImplementationType == typeof(AnotherTestService)));
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_BasedOn_Multiple_Filters_Applied()
+		{
+			// Verify that both BasedOn and If filters are applied together
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.BasedOn<IAnotherInterface>()
+				.If(t => t.Name.Contains("Another"))
+				.WithServiceSelf()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(1, descriptors.Count());
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(AnotherTestService)
+				&& d.ImplementationType == typeof(AnotherTestService)));
+			// TestService implements IAnotherInterface but doesn't contain "Another" in the name
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(TestService)));
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_InSameNamespaceAs_Multiple_Filters_Applied()
+		{
+			// Verify that both InSameNamespaceAs and If filters are applied together
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.InSameNamespaceAs<NestedTransientService1>(includeSubNamespaces: true)
+				.If(t => t.Namespace!.Contains("SubNamespace"))
+				.WithServiceSelf()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(1, descriptors.Count());
+			Assert.IsTrue(descriptors.Any(d => d.ServiceType == typeof(SubNamespaceTransientService1)
+				&& d.ImplementationType == typeof(SubNamespaceTransientService1)));
+			// NestedTransientService types are in the parent namespace
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(NestedTransientService1)));
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(NestedTransientService2)));
+		}
+
+		[TestMethod]
+		public void ServiceDescriptors_BasedOn_And_If_Complex_Predicate()
+		{
+			// Test complex predicate combining multiple conditions
+			var descriptors = new AssemblyInspector()
+				.FromAssemblyContaining<ITestService>()
+				.BasedOn<ITestService>()
+				.If(t => (
+					t.Name.Contains("Decorator")
+					&&
+#if NET8_0_OR_GREATER
+					!t.Name.EndsWith('3')
+#else
+					!t.Name.EndsWith("3")
+#endif
+					)
+					|| t.Name == "TestService")
+				.WithServiceSelf()
+				.LifestyleTransient();
+
+			Assert.IsNotNull(descriptors);
+			Assert.AreEqual(3, descriptors.Count());
+			Assert.IsTrue(descriptors.Any(d => d.ImplementationType == typeof(TestService)));
+			Assert.IsTrue(descriptors.Any(d => d.ImplementationType == typeof(TestServiceDecorator1)));
+			Assert.IsTrue(descriptors.Any(d => d.ImplementationType == typeof(TestServiceDecorator2)));
+			// Should not include TestServiceDecorator3 or AnotherTestService
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(TestServiceDecorator3)));
+			Assert.IsFalse(descriptors.Any(d => d.ImplementationType == typeof(AnotherTestService)));
+		}
+
+#endregion
 	}
 }


### PR DESCRIPTION
Updated changelog to include bug fix for issue #13 regarding filter composition in AssemblyInspector. Added new test region "Filter Composition Tests" in AssemblyInspectorTests.cs to verify various filter scenarios. Refactored AssemblyInspector.cs to streamline filter logic using LINQ, improving the application of BasedOn, InSameNamespaceAs, and If filters. Enhanced functionality and test coverage to ensure correct filter composition and application.