### PR TITLE
fix(#18): Add missing return statements in TryAdd* methods with empty DependsOn

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Bug Fixes
+
+- Fixed missing `return` statements in `TryAdd*` overload methods with empty `DependsOn` array, which caused unnecessary reflection calls and potential double-registration attempts [#18](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/18).
+
 ## 0.7.0
 
 - Decorators: removed reflection-based proxy creation (`Reflection.Emit`) and allow class decoration [#11](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/11).

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceCollectionExtensions.KeyedService.Tests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceCollectionExtensions.KeyedService.Tests.cs
@@ -81,6 +81,65 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
+		public void TryAddSingleton_EmptyDependsOn_RegistersService()
+		{
+			var serviceCollection = new ServiceCollection();
+			var emptyDependsOn = Array.Empty<Dependency>();
+			serviceCollection.TryAddSingleton(typeof(SimpleService), emptyDependsOn);
+			
+			Assert.AreEqual(1, serviceCollection.Count);
+			Assert.IsTrue(serviceCollection.IsServiceRegistered<SimpleService>());
+			
+			using var serviceProvider = serviceCollection.BuildServiceProvider();
+			var service = serviceProvider.GetRequiredService<SimpleService>();
+			Assert.IsNotNull(service);
+		}
+
+		[TestMethod]
+		public void TryAddScoped_EmptyDependsOn_RegistersService()
+		{
+			var serviceCollection = new ServiceCollection();
+			var emptyDependsOn = Array.Empty<Dependency>();
+			serviceCollection.TryAddScoped<SimpleService>(emptyDependsOn);
+			
+			Assert.AreEqual(1, serviceCollection.Count);
+			Assert.IsTrue(serviceCollection.IsServiceRegistered<SimpleService>());
+			
+			using var serviceProvider = serviceCollection.BuildServiceProvider();
+			var service = serviceProvider.GetRequiredService<SimpleService>();
+			Assert.IsNotNull(service);
+		}
+
+		[TestMethod]
+		public void TryAddTransient_EmptyDependsOn_RegistersService()
+		{
+			var serviceCollection = new ServiceCollection();
+			var emptyDependsOn = Array.Empty<Dependency>();
+			serviceCollection.TryAddTransient<SimpleService>(emptyDependsOn);
+			
+			Assert.AreEqual(1, serviceCollection.Count);
+			Assert.IsTrue(serviceCollection.IsServiceRegistered<SimpleService>());
+			
+			using var serviceProvider = serviceCollection.BuildServiceProvider();
+			var service = serviceProvider.GetRequiredService<SimpleService>();
+			Assert.IsNotNull(service);
+		}
+
+		[TestMethod]
+		public void TryAddKeyedSingleton_EmptyDependsOn_RegistersService()
+		{
+			var serviceCollection = new ServiceCollection();
+			var emptyDependsOn = Array.Empty<Dependency>();
+			serviceCollection.TryAddKeyedSingleton<SimpleService>("key1", emptyDependsOn);
+			
+			Assert.AreEqual(1, serviceCollection.Count);
+			
+			using var serviceProvider = serviceCollection.BuildServiceProvider();
+			var service = serviceProvider.GetRequiredKeyedService<SimpleService>("key1");
+			Assert.IsNotNull(service);
+		}
+
+		[TestMethod]
 		public void Resolve_KeyedService_DependsOn_Parameter()
 		{
 			var serviceCollection = new ServiceCollection();
@@ -294,6 +353,10 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			}
 
 			public IKeyedService KeyedService { get; }
+		}
+
+		public class SimpleService
+		{
 		}
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.KeyedService.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.KeyedService.cs
@@ -38,6 +38,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddSingleton(serviceType);
+				return;
 			}
 
 			GetConstructorAndParameters(serviceType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -69,6 +70,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddSingleton(serviceType, implementationType);
+				return;
 			}
 
 			GetConstructorAndParameters(implementationType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -102,6 +104,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddSingleton<TService>();
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -150,6 +153,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddScoped(serviceType);
+				return;
 			}
 
 			GetConstructorAndParameters(serviceType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -181,6 +185,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddScoped(serviceType, implementationType);
+				return;
 			}
 
 			GetConstructorAndParameters(implementationType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -214,6 +219,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddScoped<TService>();
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -277,6 +283,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddTransient(serviceType, implementationType);
+				return;
 			}
 
 			GetConstructorAndParameters(implementationType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -310,6 +317,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddTransient<TService>();
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -360,6 +368,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedSingleton<TService>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -395,6 +404,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedSingleton<TService, TImplementation>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TImplementation), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -428,6 +438,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedScoped<TService>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -463,6 +474,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedScoped<TService, TImplementation>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TImplementation), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -496,6 +508,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedTransient<TService>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -531,6 +544,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedTransient<TService, TImplementation>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TImplementation), out ConstructorInfo ctor, out ParameterInfo[] parameter);


### PR DESCRIPTION
## Issue
Fixes #18: Missing `return` in `TryAdd*` methods with empty `DependsOn` causes unnecessary work

## Changes
- Added `return` statements after inner `TryAdd*` calls when `dependsOn.Length == 0`
- Prevents unnecessary reflection calls to `GetConstructorAndParameters`
- Avoids potential double-registration attempts

## Affected Methods (14 overloads)
- `TryAddSingleton` (3 overloads)
- `TryAddScoped` (3 overloads)
- `TryAddTransient` (2 overloads)
- `TryAddKeyedSingleton` (2 overloads)
- `TryAddKeyedScoped` (2 overloads)
- `TryAddKeyedTransient` (2 overloads)

## Tests
- Added 4 new test methods to verify `TryAdd*` with empty `DependsOn` registers services correctly:
  - `TryAddSingleton_EmptyDependsOn_RegistersService`
  - `TryAddScoped_EmptyDependsOn_RegistersService`
  - `TryAddTransient_EmptyDependsOn_RegistersService`
  - `TryAddKeyedSingleton_EmptyDependsOn_RegistersService`

## Changelog
Updated `Changelog.md` with a new "Bug Fixes" section under vNext documenting this fix.
