### PR TITLE
[0.7.1] Release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## 0.7.1
+
 ### Bug Fixes
 
 - `IServiceCollection` lifetime check methods (`IsTransientServiceRegistered`, `IsScopedServiceRegistered`, `IsSingletonServiceRegistered`, and their keyed variants) now return `false` instead of throwing `InvalidOperationException` when the service is not registered.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `ResolutionContext` stack corruption in `PatchForResolutionContextTracking` when a factory delegate throws an exception. Push/Pop calls are now wrapped in `try/finally` for all 4 registration paths (non-keyed/keyed × factory/type).
 - Fixed bidirectional `IsAssignableFrom` check in `GetServiceDescriptors` method that incorrectly returned unrelated base-type registrations [#19](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/19).
   - The method now uses unidirectional matching: `serviceType == serviceDescriptor.ServiceType || serviceType.IsAssignableFrom(serviceDescriptor.ServiceType)`.
   - This fixes incorrect lifetime checks in methods like `IsTransientServiceRegistered`, `IsSingletonServiceRegistered`, etc., which depend on `.Last()` to select the correct registration.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Bug Fixes
+
+- Fixed missing `return` statements in `TryAdd*` overload methods with empty `DependsOn` array, which caused unnecessary reflection calls and potential double-registration attempts [#18](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/18).
+
 ## 0.7.0
 
 - Decorators: removed reflection-based proxy creation (`Reflection.Emit`) and allow class decoration [#11](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/11).

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 ### Bug Fixes
 
+- Fixed bidirectional `IsAssignableFrom` check in `GetServiceDescriptors` method that incorrectly returned unrelated base-type registrations [#19](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/19).
+  - The method now uses unidirectional matching: `serviceType == serviceDescriptor.ServiceType || serviceType.IsAssignableFrom(serviceDescriptor.ServiceType)`.
+  - This fixes incorrect lifetime checks in methods like `IsTransientServiceRegistered`, `IsSingletonServiceRegistered`, etc., which depend on `.Last()` to select the correct registration.
 - Fixed missing `return` statements in `TryAdd*` overload methods with empty `DependsOn` array, which caused unnecessary reflection calls and potential double-registration attempts [#18](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/18).
 
 ## 0.7.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- `IServiceCollection` lifetime check methods (`IsTransientServiceRegistered`, `IsScopedServiceRegistered`, `IsSingletonServiceRegistered`, and their keyed variants) now return `false` instead of throwing `InvalidOperationException` when the service is not registered.
 - Fixed `ResolutionContext` stack corruption in `PatchForResolutionContextTracking` when a factory delegate throws an exception. Push/Pop calls are now wrapped in `try/finally` for all 4 registration paths (non-keyed/keyed × factory/type).
 - Fixed bidirectional `IsAssignableFrom` check in `GetServiceDescriptors` method that incorrectly returned unrelated base-type registrations [#19](https://github.com/PrimordialCode/Mammoth.Extensions.DependencyInjection/issues/19).
   - The method now uses unidirectional matching: `serviceType == serviceDescriptor.ServiceType || serviceType.IsAssignableFrom(serviceDescriptor.ServiceType)`.

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
@@ -123,6 +123,45 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			}
 		}
 
+		public class TransientAsyncDisposable : IAsyncDisposable
+		{
+			public ValueTask DisposeAsync()
+			{
+				GC.SuppressFinalize(this);
+				return default;
+			}
+		}
+
+		public class AsyncDisposableConsumer : IAsyncDisposable
+		{
+			public TransientAsyncDisposable TransientAsyncDisposable { get; }
+
+			public AsyncDisposableConsumer(TransientAsyncDisposable transientAsyncDisposable)
+			{
+				TransientAsyncDisposable = transientAsyncDisposable;
+			}
+
+			public ValueTask DisposeAsync()
+			{
+				GC.SuppressFinalize(this);
+				return default;
+			}
+		}
+
+		public class AsyncDisposableConsumerFactory
+		{
+#pragma warning disable IDE0079 // Remove unnecessary suppression
+#pragma warning disable CA1822 // Mark members as static
+#pragma warning disable S2325 // Methods and properties that don't access instance data should be static
+			public AsyncDisposableConsumer Build(IServiceProvider sp)
+#pragma warning restore S2325 // Methods and properties that don't access instance data should be static
+#pragma warning restore CA1822 // Mark members as static
+#pragma warning restore IDE0079 // Remove unnecessary suppression
+			{
+				return new AsyncDisposableConsumer(sp.GetRequiredService<TransientAsyncDisposable>());
+			}
+		}
+
 		private static ServiceCollection CreateServiceCollection()
 		{
 			var serviceCollection = new ServiceCollection();
@@ -604,6 +643,109 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			Assert.AreEqual(1, fakeLogger.Collector.Count);
 			Assert.AreEqual(LogLevel.Warning, fakeLogger.LatestRecord.Level);
 			Assert.AreEqual("Open generic transient disposable registration detected, ServiceKey: (null), ServiceType: Mammoth.Extensions.DependencyInjection.Tests.DetectIncorrectUsageOfTransientDisposablesTests+ITransientOpenGeneric`1[T], ImplementationType: Mammoth.Extensions.DependencyInjection.Tests.DetectIncorrectUsageOfTransientDisposablesTests+TransientOpenGeneric`1[T]", fakeLogger.LatestRecord.Message);
+		}
+		[TestMethod]
+		public void Resolve_TransientAsyncDisposable_InRootScope_WithValidation_Throws()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientAsyncDisposable>();
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetService<TransientAsyncDisposable>());
+		}
+
+		[TestMethod]
+		public async Task Resolve_TransientAsyncDisposable_InScope_WithValidation_NoMemoryLeak()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientAsyncDisposable>();
+			var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			await using (sp)
+			{
+				await using var scope = sp.CreateAsyncScope();
+				var consumer = scope.ServiceProvider.GetService<TransientAsyncDisposable>();
+				Assert.IsNotNull(consumer);
+			}
+		}
+
+		[TestMethod]
+		public void Resolve_AsyncDisposableConsumer_using_factory_InRootScope_WithValidation_Throws()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientAsyncDisposable>();
+			serviceCollection.AddSingleton<AsyncDisposableConsumerFactory>();
+			serviceCollection.AddTransient(sp => sp.GetRequiredService<AsyncDisposableConsumerFactory>().Build(sp));
+			using var spProvider = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			Assert.ThrowsExactly<InvalidOperationException>(() => spProvider.GetService<AsyncDisposableConsumer>());
+		}
+
+		[TestMethod]
+		public async Task Resolve_AsyncDisposableConsumer_using_factory_InScope_WithValidation_NoMemoryLeak()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TransientAsyncDisposable>();
+			serviceCollection.AddSingleton<AsyncDisposableConsumerFactory>();
+			serviceCollection.AddTransient(sp => sp.GetRequiredService<AsyncDisposableConsumerFactory>().Build(sp));
+			var spProvider = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			await using (spProvider)
+			{
+				await using var scope = spProvider.CreateAsyncScope();
+				var consumer = scope.ServiceProvider.GetService<AsyncDisposableConsumer>();
+				Assert.IsNotNull(consumer);
+			}
+		}
+
+		[TestMethod]
+		public void Resolve_KeyedTransientAsyncDisposable_InRootScope_WithValidation_Throws()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedTransient<TransientAsyncDisposable>("key");
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetKeyedService<TransientAsyncDisposable>("key"));
+		}
+
+		[TestMethod]
+		public void Resolve_KeyedTransientAsyncDisposable_using_factory_InRootScope_WithValidation_Throws()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedTransient<TransientAsyncDisposable>("key", (sp, key) => new TransientAsyncDisposable());
+			using var spProvider = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = true,
+					ValidateScopes = true
+				});
+			Assert.ThrowsExactly<InvalidOperationException>(() => spProvider.GetKeyedService<TransientAsyncDisposable>("key"));
 		}
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
@@ -644,6 +644,7 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			Assert.AreEqual(LogLevel.Warning, fakeLogger.LatestRecord.Level);
 			Assert.AreEqual("Open generic transient disposable registration detected, ServiceKey: (null), ServiceType: Mammoth.Extensions.DependencyInjection.Tests.DetectIncorrectUsageOfTransientDisposablesTests+ITransientOpenGeneric`1[T], ImplementationType: Mammoth.Extensions.DependencyInjection.Tests.DetectIncorrectUsageOfTransientDisposablesTests+TransientOpenGeneric`1[T]", fakeLogger.LatestRecord.Message);
 		}
+
 		[TestMethod]
 		public void Resolve_TransientAsyncDisposable_InRootScope_WithValidation_Throws()
 		{
@@ -754,6 +755,42 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 					ValidateScopes = true
 				});
 			Assert.ThrowsExactly<InvalidOperationException>(() => spProvider.GetKeyedService<TransientAsyncDisposable>("key"));
+		}
+
+		[TestMethod]
+		public void PatchForResolutionContextTracking_FactoryThrows_StackIsClean()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<Consumer>(sp => throw new InvalidOperationException("factory error"));
+
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = false,
+					ValidateScopes = true
+				});
+
+			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetService<Consumer>());
+			Assert.AreEqual(0, ResolutionContext.CurrentStack.Count);
+		}
+
+		[TestMethod]
+		public void PatchForResolutionContextTracking_KeyedFactoryThrows_StackIsClean()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedTransient<Consumer>("key", (sp, key) => throw new InvalidOperationException("keyed factory error"));
+
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = false,
+					ValidateScopes = true
+				});
+
+			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetKeyedService<Consumer>("key"));
+			Assert.AreEqual(0, ResolutionContext.CurrentStack.Count);
 		}
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
@@ -676,6 +676,10 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 				await using var scope = sp.CreateAsyncScope();
 				var consumer = scope.ServiceProvider.GetService<TransientAsyncDisposable>();
 				Assert.IsNotNull(consumer);
+				Assert.IsFalse(scope.ServiceProvider.GetIsRootScope());
+				Assert.IsTrue(scope.ServiceProvider.GetDisposables().Contains(consumer));
+				Assert.IsTrue(sp.GetIsRootScope());
+				Assert.IsFalse(sp.GetDisposables().Contains(consumer));
 			}
 		}
 
@@ -715,6 +719,10 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 				await using var scope = spProvider.CreateAsyncScope();
 				var consumer = scope.ServiceProvider.GetService<AsyncDisposableConsumer>();
 				Assert.IsNotNull(consumer);
+				Assert.IsFalse(scope.ServiceProvider.GetIsRootScope());
+				Assert.IsTrue(scope.ServiceProvider.GetDisposables().Contains(consumer));
+				Assert.IsTrue(spProvider.GetIsRootScope());
+				Assert.IsFalse(spProvider.GetDisposables().Contains(consumer));
 			}
 		}
 

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/DetectIncorrectUsageOfTransientDisposablesTests.cs
@@ -792,6 +792,50 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetKeyedService<Consumer>("key"));
 			Assert.AreEqual(0, ResolutionContext.CurrentStack.Count);
 		}
+
+		[TestMethod]
+		public void PatchForResolutionContextTracking_TypeCtorThrows_StackIsClean()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<ThrowingConstructor>();
+
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = false,
+					ValidateScopes = true
+				});
+
+			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetService<ThrowingConstructor>());
+			Assert.AreEqual(0, ResolutionContext.CurrentStack.Count);
+		}
+
+		[TestMethod]
+		public void PatchForResolutionContextTracking_KeyedTypeCtorThrows_StackIsClean()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedTransient<ThrowingConstructor>("key");
+
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection,
+				new ExtendedServiceProviderOptions
+				{
+					DetectIncorrectUsageOfTransientDisposables = true,
+					ValidateOnBuild = false,
+					ValidateScopes = true
+				});
+
+			Assert.ThrowsExactly<InvalidOperationException>(() => sp.GetKeyedService<ThrowingConstructor>("key"));
+			Assert.AreEqual(0, ResolutionContext.CurrentStack.Count);
+		}
+
+		private sealed class ThrowingConstructor
+		{
+			public ThrowingConstructor()
+			{
+				throw new InvalidOperationException("constructor error");
+			}
+		}
 	}
 }
 

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceCollectionExtensions.KeyedService.Tests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceCollectionExtensions.KeyedService.Tests.cs
@@ -81,6 +81,65 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		}
 
 		[TestMethod]
+		public void TryAddSingleton_EmptyDependsOn_RegistersService()
+		{
+			var serviceCollection = new ServiceCollection();
+			var emptyDependsOn = Array.Empty<Dependency>();
+			serviceCollection.TryAddSingleton(typeof(SimpleService), emptyDependsOn);
+			
+			Assert.AreEqual(1, serviceCollection.Count);
+			Assert.IsTrue(serviceCollection.IsServiceRegistered<SimpleService>());
+			
+			using var serviceProvider = serviceCollection.BuildServiceProvider();
+			var service = serviceProvider.GetRequiredService<SimpleService>();
+			Assert.IsNotNull(service);
+		}
+
+		[TestMethod]
+		public void TryAddScoped_EmptyDependsOn_RegistersService()
+		{
+			var serviceCollection = new ServiceCollection();
+			var emptyDependsOn = Array.Empty<Dependency>();
+			serviceCollection.TryAddScoped<SimpleService>(emptyDependsOn);
+			
+			Assert.AreEqual(1, serviceCollection.Count);
+			Assert.IsTrue(serviceCollection.IsServiceRegistered<SimpleService>());
+			
+			using var serviceProvider = serviceCollection.BuildServiceProvider();
+			var service = serviceProvider.GetRequiredService<SimpleService>();
+			Assert.IsNotNull(service);
+		}
+
+		[TestMethod]
+		public void TryAddTransient_EmptyDependsOn_RegistersService()
+		{
+			var serviceCollection = new ServiceCollection();
+			var emptyDependsOn = Array.Empty<Dependency>();
+			serviceCollection.TryAddTransient<SimpleService>(emptyDependsOn);
+			
+			Assert.AreEqual(1, serviceCollection.Count);
+			Assert.IsTrue(serviceCollection.IsServiceRegistered<SimpleService>());
+			
+			using var serviceProvider = serviceCollection.BuildServiceProvider();
+			var service = serviceProvider.GetRequiredService<SimpleService>();
+			Assert.IsNotNull(service);
+		}
+
+		[TestMethod]
+		public void TryAddKeyedSingleton_EmptyDependsOn_RegistersService()
+		{
+			var serviceCollection = new ServiceCollection();
+			var emptyDependsOn = Array.Empty<Dependency>();
+			serviceCollection.TryAddKeyedSingleton<SimpleService>("key1", emptyDependsOn);
+			
+			Assert.AreEqual(1, serviceCollection.Count);
+			
+			using var serviceProvider = serviceCollection.BuildServiceProvider();
+			var service = serviceProvider.GetRequiredKeyedService<SimpleService>("key1");
+			Assert.IsNotNull(service);
+		}
+
+		[TestMethod]
 		public void Resolve_KeyedService_DependsOn_Parameter()
 		{
 			var serviceCollection = new ServiceCollection();
@@ -294,6 +353,10 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			}
 
 			public IKeyedService KeyedService { get; }
+		}
+
+		public class SimpleService
+		{
 		}
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceCollectionExtensions.Registration.Tests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceCollectionExtensions.Registration.Tests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.DependencyInjection;
+using Mammoth.Cqrs.Infrastructure.Tests.Infrastructure;
+
+namespace Mammoth.Extensions.DependencyInjection.Tests
+{
+	[TestClass]
+	public class ServiceCollectionExtensionsRegistrationTests
+	{
+		[TestMethod]
+		public void IsTransientServiceRegistered_Returns_False_When_Service_Not_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+
+			Assert.IsFalse(serviceCollection.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsTransientServiceRegistered(typeof(TestService)));
+		}
+
+		[TestMethod]
+		public void IsScopedServiceRegistered_Returns_False_When_Service_Not_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+
+			Assert.IsFalse(serviceCollection.IsScopedServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsScopedServiceRegistered(typeof(TestService)));
+		}
+
+		[TestMethod]
+		public void IsSingletonServiceRegistered_Returns_False_When_Service_Not_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+
+			Assert.IsFalse(serviceCollection.IsSingletonServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsSingletonServiceRegistered(typeof(TestService)));
+		}
+
+		[TestMethod]
+		public void IsKeyedSingletonServiceRegistered_Returns_False_When_Service_Not_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+
+			Assert.IsFalse(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedSingletonServiceRegistered(typeof(TestService), "key"));
+		}
+
+		[TestMethod]
+		public void IsKeyedScopedServiceRegistered_Returns_False_When_Service_Not_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+
+			Assert.IsFalse(serviceCollection.IsKeyedScopedServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedScopedServiceRegistered(typeof(TestService), "key"));
+		}
+
+		[TestMethod]
+		public void IsKeyedTransientServiceRegistered_Returns_False_When_Service_Not_Registered()
+		{
+			var serviceCollection = new ServiceCollection();
+
+			Assert.IsFalse(serviceCollection.IsKeyedTransientServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedTransientServiceRegistered(typeof(TestService), "key"));
+		}
+
+		[TestMethod]
+		public void IsTransientServiceRegistered_Returns_True_When_Registered_As_Transient()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddTransient<TestService>();
+
+			Assert.IsTrue(serviceCollection.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsScopedServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsSingletonServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void IsScopedServiceRegistered_Returns_True_When_Registered_As_Scoped()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddScoped<TestService>();
+
+			Assert.IsFalse(serviceCollection.IsTransientServiceRegistered<TestService>());
+			Assert.IsTrue(serviceCollection.IsScopedServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsSingletonServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void IsSingletonServiceRegistered_Returns_True_When_Registered_As_Singleton()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton<TestService>();
+
+			Assert.IsFalse(serviceCollection.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsScopedServiceRegistered<TestService>());
+			Assert.IsTrue(serviceCollection.IsSingletonServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void IsKeyedTransientServiceRegistered_Returns_True_When_Registered_As_Keyed_Transient()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedTransient<TestService>("key");
+
+			Assert.IsTrue(serviceCollection.IsKeyedTransientServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedScopedServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>("key"));
+		}
+
+		[TestMethod]
+		public void IsKeyedScopedServiceRegistered_Returns_True_When_Registered_As_Keyed_Scoped()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedScoped<TestService>("key");
+
+			Assert.IsFalse(serviceCollection.IsKeyedTransientServiceRegistered<TestService>("key"));
+			Assert.IsTrue(serviceCollection.IsKeyedScopedServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>("key"));
+		}
+
+		[TestMethod]
+		public void IsKeyedSingletonServiceRegistered_Returns_True_When_Registered_As_Keyed_Singleton()
+		{
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddKeyedSingleton<TestService>("key");
+
+			Assert.IsFalse(serviceCollection.IsKeyedTransientServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedScopedServiceRegistered<TestService>("key"));
+			Assert.IsTrue(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>("key"));
+		}
+	}
+}

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceCollectionExtensions.Registration.Tests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceCollectionExtensions.Registration.Tests.cs
@@ -97,33 +97,36 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		public void IsKeyedTransientServiceRegistered_Returns_True_When_Registered_As_Keyed_Transient()
 		{
 			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddKeyedTransient<TestService>("key");
+			var key = Guid.NewGuid();
+			serviceCollection.AddKeyedTransient<TestService>(key);
 
-			Assert.IsTrue(serviceCollection.IsKeyedTransientServiceRegistered<TestService>("key"));
-			Assert.IsFalse(serviceCollection.IsKeyedScopedServiceRegistered<TestService>("key"));
-			Assert.IsFalse(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>("key"));
+			Assert.IsTrue(serviceCollection.IsKeyedTransientServiceRegistered<TestService>(key));
+			Assert.IsFalse(serviceCollection.IsKeyedScopedServiceRegistered<TestService>(key));
+			Assert.IsFalse(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>(key));
 		}
 
 		[TestMethod]
 		public void IsKeyedScopedServiceRegistered_Returns_True_When_Registered_As_Keyed_Scoped()
 		{
 			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddKeyedScoped<TestService>("key");
+			var key = Guid.NewGuid();
+			serviceCollection.AddKeyedScoped<TestService>(key);
 
-			Assert.IsFalse(serviceCollection.IsKeyedTransientServiceRegistered<TestService>("key"));
-			Assert.IsTrue(serviceCollection.IsKeyedScopedServiceRegistered<TestService>("key"));
-			Assert.IsFalse(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedTransientServiceRegistered<TestService>(key));
+			Assert.IsTrue(serviceCollection.IsKeyedScopedServiceRegistered<TestService>(key));
+			Assert.IsFalse(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>(key));
 		}
 
 		[TestMethod]
 		public void IsKeyedSingletonServiceRegistered_Returns_True_When_Registered_As_Keyed_Singleton()
 		{
 			var serviceCollection = new ServiceCollection();
-			serviceCollection.AddKeyedSingleton<TestService>("key");
+			var key = Guid.NewGuid();
+			serviceCollection.AddKeyedSingleton<TestService>(key);
 
-			Assert.IsFalse(serviceCollection.IsKeyedTransientServiceRegistered<TestService>("key"));
-			Assert.IsFalse(serviceCollection.IsKeyedScopedServiceRegistered<TestService>("key"));
-			Assert.IsTrue(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>("key"));
+			Assert.IsFalse(serviceCollection.IsKeyedTransientServiceRegistered<TestService>(key));
+			Assert.IsFalse(serviceCollection.IsKeyedScopedServiceRegistered<TestService>(key));
+			Assert.IsTrue(serviceCollection.IsKeyedSingletonServiceRegistered<TestService>(key));
 		}
 	}
 }

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceProviderExtensions.Registration.Tests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceProviderExtensions.Registration.Tests.cs
@@ -272,6 +272,134 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 			Assert.IsTrue(sp.IsKeyedServiceRegistered(objectKey));
 			Assert.IsTrue(sp.IsKeyedTransientServiceRegistered<TestService>(objectKey));
 		}
+
+		#region Issue #19 - GetServiceDescriptors Bidirectional IsAssignableFrom Bug
+
+		[TestMethod]
+		public void Issue19_BaseTypeIsolation_Register_Object_As_Singleton_And_TestService_As_Transient_Verify_No_CrossMatch()
+		{
+			// Arrange: Register object as Singleton and TestService as Transient
+			// With the buggy code, object.IsAssignableFrom(TestService) = true, so GetServiceDescriptors for TestService
+			// would incorrectly include the object registration, causing .Last() to return the wrong descriptor
+			// With the fix, we only match exact types or types the query type can be assigned from
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton(typeof(object));  // Register base type as singleton
+			serviceCollection.AddTransient<TestService>();  // Register specific type as transient
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			// Act & Assert
+			// object singleton should be found when querying for object
+			Assert.IsTrue(sp.IsSingletonServiceRegistered(typeof(object)));
+
+			// TestService should be transient, NOT singleton (the fix prevents object from matching TestService)
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void Issue19_InterfaceHierarchy_Register_Interface_And_Implementation_With_Different_Lifetimes()
+		{
+			// Arrange: Register ITestService as Singleton and TestService as Transient
+			// This tests that interface and implementation registrations are correctly distinguished
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton(typeof(ITestService), typeof(TestService));  // ITestService -> TestService as Singleton
+			serviceCollection.AddTransient<TestService>();  // Direct TestService as Transient
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			// Act & Assert
+			// ITestService should be singleton (first registration)
+			Assert.IsTrue(sp.IsSingletonServiceRegistered(typeof(ITestService)));
+
+			// TestService direct registration should be transient (last registration)
+			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void Issue19_LastDescriptorSelection_Multiple_Registrations_Same_Type_Last_Wins()
+		{
+			// Arrange: Register TestService three times with different lifetimes, last one should determine the checks
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton<TestService>();
+			serviceCollection.AddScoped<TestService>();
+			serviceCollection.AddTransient<TestService>();
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			// Act
+			var descriptors = serviceCollection.GetServiceDescriptors(typeof(TestService));
+
+			// Assert - all three registrations should be present
+			Assert.AreEqual(3, descriptors.Length);
+
+			// The last one is transient
+			Assert.AreEqual(ServiceLifetime.Transient, descriptors.Last().Lifetime);
+
+			// When checking, the last registration wins
+			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());  // Last is not scoped
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());  // Last is not singleton
+		}
+
+		[TestMethod]
+		public void Issue19_UnrelatedTypes_Do_Not_Cross_Match_Even_With_Interface()
+		{
+			// Arrange: Both TestService and AnotherTestService implement IAnotherInterface
+			// The bug could cause them to cross-match due to bidirectional IsAssignableFrom
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton(typeof(IAnotherInterface), typeof(AnotherTestService));
+			serviceCollection.AddTransient<TestService>();
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			// Act & Assert
+			// Querying for TestService should NOT return the IAnotherInterface registration
+			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
+
+			// Querying for IAnotherInterface should return the singleton
+			Assert.IsTrue(sp.IsSingletonServiceRegistered(typeof(IAnotherInterface)));
+		}
+
+		[TestMethod]
+		public void Issue19_Exact_Type_Match_Only()
+		{
+			// Arrange: Register TestService as singleton
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton<TestService>();
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			// Act
+			var descriptors = serviceCollection.GetServiceDescriptors(typeof(TestService));
+
+			// Assert - should find exact match only
+			Assert.AreEqual(1, descriptors.Length);
+			Assert.AreEqual(typeof(TestService), descriptors[0].ServiceType);
+			Assert.AreEqual(ServiceLifetime.Singleton, descriptors[0].Lifetime);
+
+			// Should be registered as singleton
+			Assert.IsTrue(sp.IsSingletonServiceRegistered<TestService>());
+		}
+
+		[TestMethod]
+		public void Issue19_Implementation_Type_Matches_Interface_Registration()
+		{
+			// Arrange: Register interface with implementation and also register implementation directly
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton<ITestService, TestService>();  // Register interface->implementation as singleton
+			serviceCollection.AddTransient<TestService>();  // Register implementation directly as transient
+			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
+
+			// Act & Assert
+			// ITestService should be resolvable as singleton from the first registration
+			Assert.IsTrue(sp.IsSingletonServiceRegistered(typeof(ITestService)));
+
+			// TestService direct registration should be transient
+			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
+
+			// The bug would have caused bidirectional matching to mix these up
+			// With the fix, they are properly isolated
+		}
+
+		#endregion
 	}
 }
 

--- a/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceProviderExtensions.Registration.Tests.cs
+++ b/src/Mammoth.Extensions.DependencyInjection.Tests/ServiceProviderExtensions.Registration.Tests.cs
@@ -280,20 +280,22 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		{
 			// Arrange: Register object as Singleton and TestService as Transient
 			// With the buggy code, object.IsAssignableFrom(TestService) = true, so GetServiceDescriptors for TestService
-			// would incorrectly include the object registration, causing .Last() to return the wrong descriptor
-			// With the fix, we only match exact types or types the query type can be assigned from
+			// would incorrectly include the object registration, causing .Last() to return the wrong (Singleton) descriptor.
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddSingleton(typeof(object));  // Register base type as singleton
 			serviceCollection.AddTransient<TestService>();  // Register specific type as transient
-			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
-			// Act & Assert
-			// object singleton should be found when querying for object
-			Assert.IsTrue(sp.IsSingletonServiceRegistered(typeof(object)));
+			// Act: directly test GetServiceDescriptors - the code path that was fixed
+			var testServiceDescriptors = serviceCollection.GetServiceDescriptors(typeof(TestService));
 
-			// TestService should be transient, NOT singleton (the fix prevents object from matching TestService)
-			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());
-			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
+			// Assert: GetServiceDescriptors for TestService should NOT include the object registration
+			Assert.AreEqual(1, testServiceDescriptors.Length, "Should only return the TestService registration, not the object registration");
+			Assert.AreEqual(typeof(TestService), testServiceDescriptors[0].ServiceType);
+			Assert.AreEqual(ServiceLifetime.Transient, testServiceDescriptors[0].Lifetime);
+
+			// Also verify using IServiceCollection lifetime helpers (which use GetServiceDescriptors internally)
+			Assert.IsTrue(serviceCollection.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsSingletonServiceRegistered<TestService>());
 		}
 
 		[TestMethod]
@@ -318,26 +320,28 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		[TestMethod]
 		public void Issue19_LastDescriptorSelection_Multiple_Registrations_Same_Type_Last_Wins()
 		{
-			// Arrange: Register TestService three times with different lifetimes, last one should determine the checks
+			// Arrange: Register base type as singleton, then TestService multiple times with different lifetimes.
+			// With the buggy bidirectional check, querying GetServiceDescriptors(TestService) would also include
+			// the object singleton, causing .Last() to return the wrong (Singleton) lifetime.
 			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton(typeof(object));  // Base type - previously caused false positive matches
 			serviceCollection.AddSingleton<TestService>();
 			serviceCollection.AddScoped<TestService>();
 			serviceCollection.AddTransient<TestService>();
-			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
 			// Act
 			var descriptors = serviceCollection.GetServiceDescriptors(typeof(TestService));
 
-			// Assert - all three registrations should be present
-			Assert.AreEqual(3, descriptors.Length);
+			// Assert - only the 3 TestService registrations should be present (not the object singleton)
+			Assert.AreEqual(3, descriptors.Length, "Should only return the 3 TestService registrations, not include the object singleton");
 
 			// The last one is transient
 			Assert.AreEqual(ServiceLifetime.Transient, descriptors.Last().Lifetime);
 
-			// When checking, the last registration wins
-			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
-			Assert.IsFalse(sp.IsScopedServiceRegistered<TestService>());  // Last is not scoped
-			Assert.IsFalse(sp.IsSingletonServiceRegistered<TestService>());  // Last is not singleton
+			// When checking using IServiceCollection extension (uses GetServiceDescriptors internally), the last registration wins
+			Assert.IsTrue(serviceCollection.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsScopedServiceRegistered<TestService>());  // Last is not scoped
+			Assert.IsFalse(serviceCollection.IsSingletonServiceRegistered<TestService>());  // Last is not singleton
 		}
 
 		[TestMethod]
@@ -382,21 +386,24 @@ namespace Mammoth.Extensions.DependencyInjection.Tests
 		[TestMethod]
 		public void Issue19_Implementation_Type_Matches_Interface_Registration()
 		{
-			// Arrange: Register interface with implementation and also register implementation directly
+			// Arrange: Register interface with implementation as singleton and implementation directly as transient.
+			// With the buggy bidirectional check, GetServiceDescriptors(TestService) could incorrectly include
+			// the ITestService registration because TestService.IsAssignableFrom(ITestService) would be checked.
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddSingleton<ITestService, TestService>();  // Register interface->implementation as singleton
 			serviceCollection.AddTransient<TestService>();  // Register implementation directly as transient
-			using var sp = ServiceProviderFactory.CreateServiceProvider(serviceCollection);
 
-			// Act & Assert
-			// ITestService should be resolvable as singleton from the first registration
-			Assert.IsTrue(sp.IsSingletonServiceRegistered(typeof(ITestService)));
+			// Act: directly test GetServiceDescriptors for TestService - the code path that was fixed
+			var testServiceDescriptors = serviceCollection.GetServiceDescriptors(typeof(TestService));
 
-			// TestService direct registration should be transient
-			Assert.IsTrue(sp.IsTransientServiceRegistered<TestService>());
+			// Assert: GetServiceDescriptors for TestService should NOT include the ITestService registration
+			Assert.AreEqual(1, testServiceDescriptors.Length, "Should only return TestService registration, not ITestService");
+			Assert.AreEqual(typeof(TestService), testServiceDescriptors[0].ServiceType);
+			Assert.AreEqual(ServiceLifetime.Transient, testServiceDescriptors[0].Lifetime);
 
-			// The bug would have caused bidirectional matching to mix these up
-			// With the fix, they are properly isolated
+			// Also verify using IServiceCollection lifetime helpers (which use GetServiceDescriptors internally)
+			Assert.IsTrue(serviceCollection.IsTransientServiceRegistered<TestService>());
+			Assert.IsFalse(serviceCollection.IsSingletonServiceRegistered<TestService>());
 		}
 
 		#endregion

--- a/src/Mammoth.Extensions.DependencyInjection/DetectIncorrectUsageOfTransientDisposables.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/DetectIncorrectUsageOfTransientDisposables.cs
@@ -44,9 +44,14 @@ namespace Mammoth.Extensions.DependencyInjection
 							{
 								// track the object we are about to resolve
 								ResolutionContext.CurrentStack.Push(new ServiceIdentifier(descriptor.ServiceKey, descriptor.ServiceType));
-								var instance = originalFactory(sp);
-								ResolutionContext.CurrentStack.Pop();
-								return instance;
+								try
+								{
+									return originalFactory(sp);
+								}
+								finally
+								{
+									ResolutionContext.CurrentStack.Pop();
+								}
 							},
 							descriptor.Lifetime);
 						collection.Add(d);
@@ -61,9 +66,14 @@ namespace Mammoth.Extensions.DependencyInjection
 							sp =>
 							{
 								ResolutionContext.CurrentStack.Push(new ServiceIdentifier(descriptor.ServiceKey, descriptor.ServiceType));
-								var instance = ActivatorUtilities.CreateInstance(sp, implementationType);
-								ResolutionContext.CurrentStack.Pop();
-								return instance;
+								try
+								{
+									return ActivatorUtilities.CreateInstance(sp, implementationType);
+								}
+								finally
+								{
+									ResolutionContext.CurrentStack.Pop();
+								}
 							},
 							descriptor.Lifetime);
 						collection.Add(d);
@@ -91,9 +101,14 @@ namespace Mammoth.Extensions.DependencyInjection
 							{
 								// track the object we are about to resolve
 								ResolutionContext.CurrentStack.Push(new ServiceIdentifier(descriptor.ServiceKey, descriptor.ServiceType));
-								var instance = originalFactory(sp, key);
-								ResolutionContext.CurrentStack.Pop();
-								return instance;
+								try
+								{
+									return originalFactory(sp, key);
+								}
+								finally
+								{
+									ResolutionContext.CurrentStack.Pop();
+								}
 							},
 							descriptor.Lifetime);
 						collection.Add(d);
@@ -109,9 +124,14 @@ namespace Mammoth.Extensions.DependencyInjection
 							(sp, _) =>
 							{
 								ResolutionContext.CurrentStack.Push(new ServiceIdentifier(descriptor.ServiceKey, descriptor.ServiceType));
-								var instance = ActivatorUtilities.CreateInstance(sp, implementationType);
-								ResolutionContext.CurrentStack.Pop();
-								return instance;
+								try
+								{
+									return ActivatorUtilities.CreateInstance(sp, implementationType);
+								}
+								finally
+								{
+									ResolutionContext.CurrentStack.Pop();
+								}
 							},
 							descriptor.Lifetime);
 						collection.Add(d);

--- a/src/Mammoth.Extensions.DependencyInjection/DetectIncorrectUsageOfTransientDisposables.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/DetectIncorrectUsageOfTransientDisposables.cs
@@ -158,8 +158,8 @@ namespace Mammoth.Extensions.DependencyInjection
 					case ServiceLifetime.Transient
 						when (descriptor.IsKeyedService && descriptor.KeyedImplementationType?.IsGenericTypeDefinition == true)
 							|| (!descriptor.IsKeyedService && descriptor.ImplementationType?.IsGenericTypeDefinition == true):
-						if ((descriptor.IsKeyedService && typeof(IDisposable).IsAssignableFrom(descriptor.KeyedImplementationType))
-							|| (!descriptor.IsKeyedService && typeof(IDisposable).IsAssignableFrom(descriptor.ImplementationType)))
+						if ((descriptor.IsKeyedService && IsDisposableType(descriptor.KeyedImplementationType))
+							|| (!descriptor.IsKeyedService && IsDisposableType(descriptor.ImplementationType)))
 						{
 							if (throwOnOpenGenericTransientDisposable)
 							{
@@ -175,9 +175,9 @@ namespace Mammoth.Extensions.DependencyInjection
 						break;
 					case ServiceLifetime.Transient
 						when (descriptor is { IsKeyedService: true, KeyedImplementationType: not null }
-							&& typeof(IDisposable).IsAssignableFrom(descriptor.KeyedImplementationType))
+							&& IsDisposableType(descriptor.KeyedImplementationType))
 							|| (descriptor is { IsKeyedService: false, ImplementationType: not null }
-								&& typeof(IDisposable).IsAssignableFrom(descriptor.ImplementationType)):
+								&& IsDisposableType(descriptor.ImplementationType)):
 						collection.Add(CreatePatchedDescriptor(descriptor, allowSingletonToResolveTransientDisposables));
 						break;
 					case ServiceLifetime.Transient
@@ -214,10 +214,10 @@ namespace Mammoth.Extensions.DependencyInjection
 					//check the ResolutionContext to see if the service is being resolved by a singleton
 					//if it is, then it's safe to resolve the transient disposable service
 					if (sp.GetIsRootScope()
-						&& originalResult is IDisposable d
+						&& (originalResult is IDisposable || originalResult is IAsyncDisposable)
 						&& !IsResolvedBySingleton(sp, allowSingletonToResolveTransientDisposables))
 					{
-						ThrowTransientDisposableException(original.ServiceKey, original.ServiceType, d.GetType(), isFactory: true);
+						ThrowTransientDisposableException(original.ServiceKey, original.ServiceType, originalResult.GetType(), isFactory: true);
 					}
 
 					return originalResult;
@@ -243,10 +243,10 @@ namespace Mammoth.Extensions.DependencyInjection
 					//check the ResolutionContext to see if the service is being resolved by a singleton
 					//if it is, then it's safe to resolve the transient disposable service
 					if (sp.GetIsRootScope()
-						&& originalResult is IDisposable d
+						&& (originalResult is IDisposable || originalResult is IAsyncDisposable)
 						&& !IsResolvedBySingleton(sp, allowSingletonToResolveTransientDisposables))
 					{
-						ThrowTransientDisposableException(original.ServiceKey, original.ServiceType, d.GetType(), isFactory: true);
+						ThrowTransientDisposableException(original.ServiceKey, original.ServiceType, originalResult.GetType(), isFactory: true);
 					}
 
 					return originalResult;
@@ -389,6 +389,9 @@ namespace Mammoth.Extensions.DependencyInjection
 			throw new InvalidOperationException(sb.ToString());
 		}
 #endif
+
+		private static bool IsDisposableType(Type? type) =>
+			type != null && (typeof(IDisposable).IsAssignableFrom(type) || typeof(IAsyncDisposable).IsAssignableFrom(type));
 
 		private static bool IsResolvedBySingleton(
 			IServiceProvider sp,

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.KeyedService.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.KeyedService.cs
@@ -38,6 +38,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddSingleton(serviceType);
+				return;
 			}
 
 			GetConstructorAndParameters(serviceType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -69,6 +70,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddSingleton(serviceType, implementationType);
+				return;
 			}
 
 			GetConstructorAndParameters(implementationType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -102,6 +104,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddSingleton<TService>();
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -150,6 +153,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddScoped(serviceType);
+				return;
 			}
 
 			GetConstructorAndParameters(serviceType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -181,6 +185,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddScoped(serviceType, implementationType);
+				return;
 			}
 
 			GetConstructorAndParameters(implementationType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -214,6 +219,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddScoped<TService>();
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -277,6 +283,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddTransient(serviceType, implementationType);
+				return;
 			}
 
 			GetConstructorAndParameters(implementationType, out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -310,6 +317,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddTransient<TService>();
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -360,6 +368,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedSingleton<TService>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -395,6 +404,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedSingleton<TService, TImplementation>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TImplementation), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -428,6 +438,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedScoped<TService>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -463,6 +474,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedScoped<TService, TImplementation>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TImplementation), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -496,6 +508,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedTransient<TService>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TService), out ConstructorInfo ctor, out ParameterInfo[] parameter);
@@ -531,6 +544,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			if (dependsOn.Length == 0)
 			{
 				services.TryAddKeyedTransient<TService, TImplementation>(serviceKey);
+				return;
 			}
 
 			GetConstructorAndParameters(typeof(TImplementation), out ConstructorInfo ctor, out ParameterInfo[] parameter);

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
@@ -51,7 +51,7 @@ namespace Mammoth.Extensions.DependencyInjection
 		}
 
 		/// <summary>
-		/// Gets an array of <see cref="ServiceDescriptor"/> objects for services that are assignable to or from the specified <paramref name="serviceType"/>.
+		/// Gets an array of <see cref="ServiceDescriptor"/> objects for services that are assignable from the specified <paramref name="serviceType"/>.
 		/// </summary>
 		/// <param name="services">The service collection.</param>
 		/// <param name="serviceType">The type of the service.</param>

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
@@ -66,7 +66,7 @@ namespace Mammoth.Extensions.DependencyInjection
 
 			return services.Where(serviceDescriptor =>
 				(isKeyedService == null || serviceDescriptor.IsKeyedService == isKeyedService)
-				&& (serviceType == serviceDescriptor.ServiceType || serviceType.IsAssignableFrom(serviceDescriptor.ServiceType)))
+				&& serviceType.IsAssignableFrom(serviceDescriptor.ServiceType))
 				.ToArray();
 		}
 

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
@@ -174,7 +174,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			}
 
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: true)
-				.Where(d => d.ServiceKey == serviceKey)
+				.Where(d => Equals(d.ServiceKey, serviceKey))
 				.ToArray();
 			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Singleton;
 		}
@@ -210,7 +210,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			}
 
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: true)
-				.Where(d => d.ServiceKey == serviceKey)
+				.Where(d => Equals(d.ServiceKey, serviceKey))
 				.ToArray();
 			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Scoped;
 		}
@@ -246,7 +246,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			}
 
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: true)
-				.Where(d => d.ServiceKey == serviceKey)
+				.Where(d => Equals(d.ServiceKey, serviceKey))
 				.ToArray();
 			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Transient;
 		}

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
@@ -84,7 +84,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			}
 
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: false);
-			return descriptors.Last().Lifetime == ServiceLifetime.Transient;
+			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Transient;
 		}
 
 		/// <summary>
@@ -112,7 +112,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			}
 
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: false);
-			return descriptors.Last().Lifetime == ServiceLifetime.Scoped;
+			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Scoped;
 		}
 
 		/// <summary>
@@ -140,7 +140,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			}
 
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: false);
-			return descriptors.Last().Lifetime == ServiceLifetime.Singleton;
+			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Singleton;
 		}
 
 		/// <summary>
@@ -176,7 +176,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: true)
 				.Where(d => d.ServiceKey == serviceKey)
 				.ToArray();
-			return descriptors.Last().Lifetime == ServiceLifetime.Singleton;
+			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Singleton;
 		}
 
 		/// <summary>
@@ -212,7 +212,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: true)
 				.Where(d => d.ServiceKey == serviceKey)
 				.ToArray();
-			return descriptors.Last().Lifetime == ServiceLifetime.Scoped;
+			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Scoped;
 		}
 
 		/// <summary>
@@ -248,7 +248,7 @@ namespace Mammoth.Extensions.DependencyInjection
 			var descriptors = services.GetServiceDescriptors(serviceType, isKeyedService: true)
 				.Where(d => d.ServiceKey == serviceKey)
 				.ToArray();
-			return descriptors.Last().Lifetime == ServiceLifetime.Transient;
+			return descriptors.Length > 0 && descriptors[descriptors.Length - 1].Lifetime == ServiceLifetime.Transient;
 		}
 
 		/// <summary>

--- a/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
+++ b/src/Mammoth.Extensions.DependencyInjection/ServiceCollectionExtensions.Registration.cs
@@ -66,7 +66,7 @@ namespace Mammoth.Extensions.DependencyInjection
 
 			return services.Where(serviceDescriptor =>
 				(isKeyedService == null || serviceDescriptor.IsKeyedService == isKeyedService)
-				&& (serviceType.IsAssignableFrom(serviceDescriptor.ServiceType) || serviceDescriptor.ServiceType.IsAssignableFrom(serviceType)))
+				&& (serviceType == serviceDescriptor.ServiceType || serviceType.IsAssignableFrom(serviceDescriptor.ServiceType)))
 				.ToArray();
 		}
 


### PR DESCRIPTION
This pull request introduces a patch release (0.7.1) focused on bug fixes and improvements to service registration and resolution validation in the dependency injection library. The most significant changes address lifetime check methods, resolution context tracking, and registration behaviors for empty dependency arrays. Comprehensive tests have been added to verify these fixes and behaviors.

### Bug Fixes and Validation Improvements

* The `IServiceCollection` lifetime check methods (`IsTransientServiceRegistered`, `IsScopedServiceRegistered`, `IsSingletonServiceRegistered`, and their keyed variants) now return `false` instead of throwing `InvalidOperationException` when the service is not registered.
* Fixed stack corruption in `ResolutionContext` when a factory delegate throws an exception by wrapping Push/Pop calls in `try/finally` for all registration paths, ensuring stack cleanliness after exceptions. [[1]](diffhunk://#diff-c275fec9c453c2a42515bc5ab47e30fa4130ff1426aef2f6e000a9a34e122cb8R5-R15) [[2]](diffhunk://#diff-d12b55be4d5f92109a47a87c30d4deea384aaa3847eb3a59b3c0eb69a725a17dR647-R838)
* Corrected the `GetServiceDescriptors` method to use unidirectional `IsAssignableFrom` checks, preventing incorrect lifetime checks and unrelated base-type registrations.

### Registration Behavior

* Fixed missing `return` statements in `TryAdd*` overloads with empty `DependsOn` arrays, preventing unnecessary reflection and potential double-registration.
* Added tests to confirm that `TryAddSingleton`, `TryAddScoped`, `TryAddTransient`, and `TryAddKeyedSingleton` correctly register services when provided an empty dependency array. [[1]](diffhunk://#diff-0b5c5f243fd1303400e1b6384490678844465a6534be9b458edb71fa7d59a05aR83-R141) [[2]](diffhunk://#diff-0b5c5f243fd1303400e1b6384490678844465a6534be9b458edb71fa7d59a05aR357-R360)

### Test Coverage

* Added extensive tests for lifetime check methods to ensure correct behavior for both registered and unregistered services, including keyed variants.
* Introduced tests for async disposable transient services and consumers, validating correct exception handling, memory leak prevention, and proper disposal in scoped and root contexts. [[1]](diffhunk://#diff-d12b55be4d5f92109a47a87c30d4deea384aaa3847eb3a59b3c0eb69a725a17dR126-R164) [[2]](diffhunk://#diff-d12b55be4d5f92109a47a87c30d4deea384aaa3847eb3a59b3c0eb69a725a17dR647-R838)
* Added tests to ensure resolution context stack remains clean after exceptions in factory and constructor paths, for both keyed and non-keyed registrations.

These changes collectively improve reliability, correctness, and developer experience when working with service registrations and resolution in the library.